### PR TITLE
fix: workaround redux tools bug

### DIFF
--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Angular ngrx-data library ChangeLog
 
+<a name="1.0.0-alpha.5"></a>
+# release 1.0.0-alpha.5 (2018-02-14)
+* Workaround redux tools replay bug
+
 <a name="1.0.0-alpha.4"></a>
 # release 1.0.0-alpha.4 (2018-02-13)
 * Upgrade to ngrx v5.1

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngrx-data",
-  "version": "1.0.0-alpha.4",
+  "version": "1.0.0-alpha.5",
   "repository": "https://github.com/johnpapa/angular-ngrx-data.git",
   "license": "MIT",
   "peerDependencies": {

--- a/lib/src/default-data.service.ts
+++ b/lib/src/default-data.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, Optional } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 
 import { Observable } from 'rxjs/Observable';
@@ -137,10 +137,12 @@ export class DefaultDataService<T> implements EntityCollectionDataService<T> {
 @Injectable()
 export class DefaultDataServiceFactory {
   constructor(
-    protected config: EntityDataServiceConfig,
     protected http: HttpClient,
-    protected httpUrlGenerator: HttpUrlGenerator
-  ) { }
+    protected httpUrlGenerator: HttpUrlGenerator,
+    @Optional() protected config: EntityDataServiceConfig,
+  ) {
+    config = config || new EntityDataServiceConfig();
+  }
 
   create<T>(entityName: string) {
     return new DefaultDataService<T>(this.http, this.httpUrlGenerator, this.config, entityName);

--- a/lib/src/entity-collection.reducer.spec.ts
+++ b/lib/src/entity-collection.reducer.spec.ts
@@ -25,7 +25,9 @@ const metadata: EntityMetadataMap = {
 describe('EntityCollectionReducer', () => {
   // action factory never changes in these tests
   const entityActionFactory = new EntityActionFactory();
-  const createAction = entityActionFactory.create.bind(entityActionFactory);
+  const createAction:
+    (entityName: string, op: EntityOp, payload: any) => EntityAction = entityActionFactory.create.bind(entityActionFactory);
+
   const toHeroUpdate = toUpdateFactory<Hero>();
 
   let entityReducerFactory: EntityReducerFactory;

--- a/lib/src/entity-dispatcher.spec.ts
+++ b/lib/src/entity-dispatcher.spec.ts
@@ -3,33 +3,23 @@ import { EntityDispatcher, EntityDispatcherFactory } from './entity-dispatcher';
 import { EntityCommands } from './entity-commands';
 import { Update } from './ngrx-entity-models';
 
-// region test helpers
-///// test helpers /////
-
 class Hero {
   id: number;
   name: string;
   saying?: string;
 }
 
-class TestStore  {
-  dispatch = jasmine.createSpy('dispatch');
-
-  get dispatchedAction() {
-    return <EntityAction> this.dispatch.calls.argsFor(0)[0];
-  }
-}
-// endregion test helpers
-
 describe('EntityDispatcher', () => {
 
   commandDispatchTest(entityDispatcherTestSetup);
 
   function entityDispatcherTestSetup() {
+    // only interested in calls to store.dispatch()
+    const testStore = jasmine.createSpyObj('store', ['dispatch']);
+
     const selectId = (entity: any) => entity.id;
-    const testStore = new TestStore();
     const entityActionFactory = new EntityActionFactory();
-    const dispatcher = new EntityDispatcher('Hero', entityActionFactory, <any> testStore, selectId)
+    const dispatcher = new EntityDispatcher('Hero', entityActionFactory, testStore, selectId)
     return { dispatcher, testStore };
   }
 });
@@ -38,11 +28,15 @@ describe('EntityDispatcher', () => {
 
 /** Test that implementer of EntityCommands dispatches properly */
 export function commandDispatchTest(
-  setup: () => { dispatcher: EntityDispatcher<Hero>, testStore: TestStore}
+  setup: () => { dispatcher: EntityDispatcher<Hero>, testStore: any}
  ) {
 
   let dispatcher: EntityDispatcher<Hero>;
-  let testStore: TestStore;
+  let testStore: { dispatch: jasmine.Spy };
+
+  function dispatchedAction() {
+    return <EntityAction> testStore.dispatch.calls.argsFor(0)[0];
+  }
 
   beforeEach(() => {
     const s = setup();
@@ -58,15 +52,15 @@ export function commandDispatchTest(
     const hero: Hero = {id: 42, name: 'test'};
     dispatcher.add(hero);
 
-    expect(testStore.dispatchedAction.op).toBe(EntityOp.SAVE_ADD);
-    expect(testStore.dispatchedAction.payload).toBe(hero);
+    expect(dispatchedAction().op).toBe(EntityOp.SAVE_ADD);
+    expect(dispatchedAction().payload).toBe(hero);
   });
 
   it('#delete(42) dispatches SAVE_DELETE for the id:42', () => {
     dispatcher.delete(42);
 
-    expect(testStore.dispatchedAction.op).toBe(EntityOp.SAVE_DELETE);
-    expect(testStore.dispatchedAction.payload).toBe(42);
+    expect(dispatchedAction().op).toBe(EntityOp.SAVE_DELETE);
+    expect(dispatchedAction().payload).toBe(42);
   });
 
   it('#delete(hero) dispatches SAVE_DELETE for the hero.id', () => {
@@ -75,38 +69,38 @@ export function commandDispatchTest(
 
     dispatcher.delete(hero);
 
-    expect(testStore.dispatchedAction.op).toBe(EntityOp.SAVE_DELETE);
-    expect(testStore.dispatchedAction.payload).toBe(id);
+    expect(dispatchedAction().op).toBe(EntityOp.SAVE_DELETE);
+    expect(dispatchedAction().payload).toBe(id);
   });
 
   it('#getAll() dispatches QUERY_ALL for the Hero collection', () => {
     dispatcher.getAll();
 
-    expect(testStore.dispatchedAction.op).toBe(EntityOp.QUERY_ALL);
-    expect(testStore.dispatchedAction.entityName).toBe('Hero');
+    expect(dispatchedAction().op).toBe(EntityOp.QUERY_ALL);
+    expect(dispatchedAction().entityName).toBe('Hero');
   });
 
   it('#getByKey(42) dispatches QUERY_BY_KEY for the id:42', () => {
     dispatcher.getByKey(42);
 
-    expect(testStore.dispatchedAction.op).toBe(EntityOp.QUERY_BY_KEY);
-    expect(testStore.dispatchedAction.payload).toBe(42);
+    expect(dispatchedAction().op).toBe(EntityOp.QUERY_BY_KEY);
+    expect(dispatchedAction().payload).toBe(42);
   });
 
   it('#getWithQuery(QueryParams) dispatches QUERY_MANY', () => {
     dispatcher.getWithQuery({name: 'B'});
 
-    expect(testStore.dispatchedAction.op).toBe(EntityOp.QUERY_MANY);
-    expect(testStore.dispatchedAction.entityName).toBe('Hero');
-    expect(testStore.dispatchedAction.payload).toEqual({name: 'B'}, 'params')
+    expect(dispatchedAction().op).toBe(EntityOp.QUERY_MANY);
+    expect(dispatchedAction().entityName).toBe('Hero');
+    expect(dispatchedAction().payload).toEqual({name: 'B'}, 'params')
   });
 
   it('#getWithQuery(string) dispatches QUERY_MANY', () => {
     dispatcher.getWithQuery('name=B');
 
-    expect(testStore.dispatchedAction.op).toBe(EntityOp.QUERY_MANY);
-    expect(testStore.dispatchedAction.entityName).toBe('Hero');
-    expect(testStore.dispatchedAction.payload).toEqual('name=B', 'params')
+    expect(dispatchedAction().op).toBe(EntityOp.QUERY_MANY);
+    expect(dispatchedAction().entityName).toBe('Hero');
+    expect(dispatchedAction().payload).toEqual('name=B', 'params')
   });
 
   it('#update(hero) dispatches SAVE_UPDATE with an update payload', () => {
@@ -115,8 +109,8 @@ export function commandDispatchTest(
 
     dispatcher.update(hero);
 
-    expect(testStore.dispatchedAction.op).toBe(EntityOp.SAVE_UPDATE);
-    expect(testStore.dispatchedAction.payload).toEqual(expectedUpdate);
+    expect(dispatchedAction().op).toBe(EntityOp.SAVE_UPDATE);
+    expect(dispatchedAction().payload).toEqual(expectedUpdate);
   });
 
   /*** Cache-only operations ***/
@@ -128,16 +122,16 @@ export function commandDispatchTest(
     ];
     dispatcher.addAllToCache(heroes);
 
-    expect(testStore.dispatchedAction.op).toBe(EntityOp.ADD_ALL);
-    expect(testStore.dispatchedAction.payload).toBe(heroes);
+    expect(dispatchedAction().op).toBe(EntityOp.ADD_ALL);
+    expect(dispatchedAction().payload).toBe(heroes);
   });
 
   it('#addOneToCache dispatches ADD_ONE', () => {
     const hero: Hero = { id: 42, name: 'test' };
     dispatcher.addOneToCache(hero);
 
-    expect(testStore.dispatchedAction.op).toBe(EntityOp.ADD_ONE);
-    expect(testStore.dispatchedAction.payload).toBe(hero);
+    expect(dispatchedAction().op).toBe(EntityOp.ADD_ONE);
+    expect(dispatchedAction().payload).toBe(hero);
   });
 
   it('#addManyToCache dispatches ADD_MANY', () => {
@@ -147,23 +141,23 @@ export function commandDispatchTest(
     ];
     dispatcher.addManyToCache(heroes);
 
-    expect(testStore.dispatchedAction.op).toBe(EntityOp.ADD_MANY);
-    expect(testStore.dispatchedAction.payload).toBe(heroes);
+    expect(dispatchedAction().op).toBe(EntityOp.ADD_MANY);
+    expect(dispatchedAction().payload).toBe(heroes);
   });
 
   it('#clearCache() dispatches REMOVE_ALL for the Hero collection', () => {
     dispatcher.clearCache();
 
-    expect(testStore.dispatchedAction.op).toBe(EntityOp.REMOVE_ALL);
-    expect(testStore.dispatchedAction.entityName).toBe('Hero');
+    expect(dispatchedAction().op).toBe(EntityOp.REMOVE_ALL);
+    expect(dispatchedAction().entityName).toBe('Hero');
   });
 
   it('#removeOneFromCache(key) dispatches REMOVE_ONE', () => {
     const id = 42;
     dispatcher.removeOneFromCache(id);
 
-    expect(testStore.dispatchedAction.op).toBe(EntityOp.REMOVE_ONE);
-    expect(testStore.dispatchedAction.payload).toBe(id);
+    expect(dispatchedAction().op).toBe(EntityOp.REMOVE_ONE);
+    expect(dispatchedAction().payload).toBe(id);
   });
 
   it('#removeOneFromCache(entity) dispatches REMOVE_ONE', () => {
@@ -171,16 +165,16 @@ export function commandDispatchTest(
     const hero: Hero = {id, name: 'test'};
     dispatcher.removeOneFromCache(hero);
 
-    expect(testStore.dispatchedAction.op).toBe(EntityOp.REMOVE_ONE);
-    expect(testStore.dispatchedAction.payload).toBe(id);
+    expect(dispatchedAction().op).toBe(EntityOp.REMOVE_ONE);
+    expect(dispatchedAction().payload).toBe(id);
   });
 
   it('#removeManyFromCache(keys) dispatches REMOVE_MANY', () => {
     const keys = [42, 84];
     dispatcher.removeManyFromCache(keys);
 
-    expect(testStore.dispatchedAction.op).toBe(EntityOp.REMOVE_MANY);
-    expect(testStore.dispatchedAction.payload).toBe(keys);
+    expect(dispatchedAction().op).toBe(EntityOp.REMOVE_MANY);
+    expect(dispatchedAction().payload).toBe(keys);
   });
 
   it('#removeManyFromCache(entities) dispatches REMOVE_MANY', () => {
@@ -191,8 +185,8 @@ export function commandDispatchTest(
     const keys = heroes.map(h => h.id);
     dispatcher.removeManyFromCache(heroes);
 
-    expect(testStore.dispatchedAction.op).toBe(EntityOp.REMOVE_MANY);
-    expect(testStore.dispatchedAction.payload).toEqual(keys);
+    expect(dispatchedAction().op).toBe(EntityOp.REMOVE_MANY);
+    expect(dispatchedAction().payload).toEqual(keys);
   });
 
   it('#toUpdate() helper method creates Update<T>', () => {
@@ -207,8 +201,8 @@ export function commandDispatchTest(
     const update = { id: 42, changes: hero };
     dispatcher.updateOneInCache(hero);
 
-    expect(testStore.dispatchedAction.op).toBe(EntityOp.UPDATE_ONE);
-    expect(testStore.dispatchedAction.payload).toEqual(update);
+    expect(dispatchedAction().op).toBe(EntityOp.UPDATE_ONE);
+    expect(dispatchedAction().payload).toEqual(update);
   });
 
   it('#updateManyInCache dispatches UPDATE_MANY', () => {
@@ -222,8 +216,8 @@ export function commandDispatchTest(
     ];
     dispatcher.updateManyInCache(heroes);
 
-    expect(testStore.dispatchedAction.op).toBe(EntityOp.UPDATE_MANY);
-    expect(testStore.dispatchedAction.payload).toEqual(updates);
+    expect(dispatchedAction().op).toBe(EntityOp.UPDATE_MANY);
+    expect(dispatchedAction().payload).toEqual(updates);
   });
 
   it('#upsertOneInCache dispatches UPSERT_ONE', () => {
@@ -231,8 +225,8 @@ export function commandDispatchTest(
     const upsert = { id: 42, changes: hero };
     dispatcher.upsertOneInCache(hero);
 
-    expect(testStore.dispatchedAction.op).toBe(EntityOp.UPSERT_ONE);
-    expect(testStore.dispatchedAction.payload).toEqual(upsert);
+    expect(dispatchedAction().op).toBe(EntityOp.UPSERT_ONE);
+    expect(dispatchedAction().payload).toEqual(upsert);
   });
 
   it('#upsertManyInCache dispatches UPSERT_MANY', () => {
@@ -246,7 +240,7 @@ export function commandDispatchTest(
     ];
     dispatcher.upsertManyInCache(heroes);
 
-    expect(testStore.dispatchedAction.op).toBe(EntityOp.UPSERT_MANY);
-    expect(testStore.dispatchedAction.payload).toEqual(upserts);
+    expect(dispatchedAction().op).toBe(EntityOp.UPSERT_MANY);
+    expect(dispatchedAction().payload).toEqual(upserts);
   });
 }

--- a/lib/src/entity.reducer.ts
+++ b/lib/src/entity.reducer.ts
@@ -96,3 +96,7 @@ export class EntityReducerFactory {
     keys.forEach(key => this.registerReducer(key, reducers[key]));
   }
 }
+
+export function createEntityReducer(entityReducerFactory: EntityReducerFactory) {
+  return entityReducerFactory.create();
+}

--- a/lib/src/entity.service.spec.ts
+++ b/lib/src/entity.service.spec.ts
@@ -1,87 +1,93 @@
 /** TODO: much more testing */
-import { Selector } from '@ngrx/store';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { StoreModule, Store } from '@ngrx/store';
 
-import { BehaviorSubject } from 'rxjs/BehaviorSubject';
-import { distinctUntilChanged, map, pluck } from 'rxjs/operators';
+import { EntityAction, EntityActionFactory, EntityOp } from './entity.actions';
+import { EntityCache } from './interfaces';
+import { EntityCollection } from './entity-definition';
+import { ENTITY_METADATA_TOKEN } from './interfaces';
+import { EntityService, EntityServiceFactory } from './entity.service';
+
+import { _NgrxDataModuleWithoutEffects } from './ngrx-data.module'
 
 import { commandDispatchTest } from './entity-dispatcher.spec';
-import { EntityDispatcherFactory } from './entity-dispatcher';
-import { EntityAction, EntityActionFactory } from './entity.actions';
-import { EntityCollection } from './entity-definition';
-import { EntityCollectionCreator } from './entity-collection-creator';
-import { EntityDefinitionService } from './entity-definition.service';
-import { EntityService, EntityServiceFactory } from './entity.service';
-import { EntitySelectors$Factory } from './entity.selectors$';
 
-describe('EntityService', () => {
-  describe('Commands', () => {
-    commandDispatchTest(entityServiceTestSetup);
-  })
-});
-
-//// Test helpers ////
 class Hero {
   id: number;
   name: string;
   saying?: string;
 }
 
+describe('EntityService', () => {
+  describe('Commands', () => {
+    commandDispatchTest(heroDispatcherSetup);
+  })
+
+  describe('Selectors$', () => {
+
+    let heroService: EntityService<Hero>;
+    let store: Store<EntityCache>;
+    let createAction:
+      (entityName: string, op: EntityOp, payload: any) => EntityAction;
+
+    function dispatchedAction() {
+      return <EntityAction> (<jasmine.Spy> store.dispatch).calls.argsFor(0)[0];
+    }
+
+    beforeEach(() => {
+      const { entityActionFactory, entityServiceFactory, testStore } = entityServiceFactorySetup();
+      heroService = entityServiceFactory.create<Hero>('Hero');
+      store = testStore;
+      createAction = entityActionFactory.create.bind(entityActionFactory);
+    });
+
+    it('can get collection from collection$', () => {
+      let collection: EntityCollection<Hero>;
+      const action = createAction('Hero', EntityOp.ADD_ALL, [
+        { id: 1, name: 'A'}
+      ])
+      store.dispatch(action);
+      heroService.collection$.subscribe(c => {
+        collection = c
+      });
+
+      expect(collection.ids).toEqual([1]);
+    });
+
+  });
+});
+
+// region test helpers
 const heroMetadata = {
   entityName: 'Hero'
 }
 
-class TestStore  {
-  collection$ = new BehaviorSubject({
-    Hero: {
-      ids: [],
-      entities: {},
-      filter: undefined,
-      loading: false
-    } as EntityCollection<Hero>
+function entityServiceFactorySetup() {
+
+  TestBed.configureTestingModule({
+    imports: [
+      StoreModule.forRoot({}),
+      _NgrxDataModuleWithoutEffects
+    ],
+    providers: [
+      { provide: ENTITY_METADATA_TOKEN, multi: true, useValue: {
+        Hero: heroMetadata
+      }},
+    ]
   });
 
-  dispatch = jasmine.createSpy('dispatch');
+  const testStore: Store<EntityCache> = TestBed.get(Store);
+  spyOn(testStore, 'dispatch').and.callThrough();
 
-  get dispatchedAction() {
-    return <EntityAction> this.dispatch.calls.argsFor(0)[0];
-  }
+  const entityActionFactory: EntityActionFactory = TestBed.get(EntityActionFactory);
+  const entityServiceFactory: EntityServiceFactory = TestBed.get(EntityServiceFactory);
 
-  select() {
-    return {
-      select: <V>(selector: Selector<EntityCollection<Hero>, V>) =>
-        this.collection$.pipe(
-          map(c => selector),
-          distinctUntilChanged()
-        )
-    }
-  }
+  return { entityActionFactory, entityServiceFactory, testStore };
 }
 
-function entityServiceTestSetup() {
-  const testStore = new TestStore();
-
-  const entityActionFactory = new EntityActionFactory();
-
-  const entityDefinitionService =
-    new EntityDefinitionService([{Hero: heroMetadata}]);
-
-  const entityDispatcherFactory =
-    new EntityDispatcherFactory(entityActionFactory, <any> testStore);
-
-  const entityCollectionCreator =
-    new EntityCollectionCreator(entityDefinitionService);
-
-  const entitySelectors$Factory =
-    new EntitySelectors$Factory('TestEntityCache', entityCollectionCreator, <any> testStore);
-
-  const entityServiceFactory = new EntityServiceFactory(
-    entityDispatcherFactory,
-    entityDefinitionService,
-    entitySelectors$Factory
-  );
-
-  const dispatcher = entityServiceFactory.create<Hero>('Hero');
+function heroDispatcherSetup() {
+  const { entityServiceFactory, testStore } = entityServiceFactorySetup();
+  const dispatcher: EntityService<Hero> = entityServiceFactory.create<Hero>('Hero');
   return { dispatcher, testStore };
 }
-
-
+// endregion test helpers

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -17,7 +17,7 @@ export * from './entity.service';
 export * from './interfaces';
 export * from './persistence-result-handler.service';
 // export * from './ngrx-entity-models'; // try not to export
-export * from './ngrx-data.module';
+export { NgrxDataModule, NgrxDataModuleConfig } from './ngrx-data.module';
 export * from './utils';
 
 export { Pluralizer } from './pluralizer';


### PR DESCRIPTION
- Threw when replay because entityCache and appConfig missing at start
- Also refactored to support EntityService tests (added some)
- Created internal only `_NgrxDataModuleWithoutEffects` to make testing easier
- This is release `ngrx-data@1.0.0-alpha.5`