### PR TITLE
feat: support optimistic saves and change tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,26 @@ Follow these instructions to
 [install them in your browser](https://github.com/zalmoxisus/redux-devtools-extension)
 and learn how to use them.
 
+## Debug the library in browser dev tools
+
+When running _tests_, open the browser dev tools, go to the "Sources" tab,
+and look for the library files by name.
+
+> In chrome, type [Command-P] and letters of the file name.
+
+Unfortunately, when _running the app_ (e.g., with `ng serve`), 
+you cannot access the _ngrx-data_ library source files.
+The browser dev tools only reveal the _consolidated build file_, `ngrx-data.js`,
+which is ECMA 2015, not TypeScript.
+
+> You can still access the application source files.
+
+The app browser does not refresh when you make changes to the library.
+You must re-generate the library packages with `npm run build-lib`
+to see your changes.
+
+We are looking into this problem and hope to have a better experience soon.
+
 ## Build the app against the npm package
 
 The demo app is setup to build and run against the version of the library in

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,10 +18,12 @@ This page and other guide pages are markdown pages in the repository `docs` fold
 
 * [Introduction](introduction.md) 
 * [Entity Metadata](entity-metadata.md)
+* [Entity Collection](entity-collection.md)
 * [Entity Service](entity-service.md)
 * [Entity DataService](entity-dataservice.md)
 * [Entity Actions](entity-actions.md)
 * [Entity Reducer](entity-reducer.md)
+* [Entity Change Tracker](entity-change-tracker.md)
 * [Extension Points](extension-points.md)
 * [Limitations](limitations.md)
 * [FAQ: Frequently Asked Questions](faq.md)

--- a/docs/entity-change-tracker.md
+++ b/docs/entity-change-tracker.md
@@ -1,0 +1,51 @@
+# EntityChangeTracker
+
+Can add the current value of a cached entity in that entity's
+`collection.originalValues` map and later _revert_ the entity to
+this _original value_.
+
+This feature is most valuable during _optimistic_ saves that
+add, update, and delete entity data in the remote storage (e.g., a database).
+
+## Change tracking and optimistic saves
+
+The `EntityActions` whose operation names end in `_OPTIMISTIC` begin
+an _optimistic_ save.
+The default [`EntityCollectionReducer`](entity-reducer.md) _immediately_ updates the cached collection _before_ sending the HTTP request to do the same on the server.
+
+The operation is _optimistic_ because it is presumed to succeed more often than not.
+The _pessimistic_ versions of these actions _do not update_ the cached collection
+_until_ the server responds.
+
+### Save errors
+
+If the server request timeouts or the server rejects the save request,
+the _nrgx_ reducer is called with an error action ending in `_ERROR`.
+
+**The reducer does nothing with save errors.**
+
+There is no harm if the operation was _pessimistic_.
+The collection had not been updated so there is no obvious inconsistency with the state
+of the entity on the server.
+
+It the operation was _optimistic_, the entity in the cached collection has been updated and is no longer
+consistent with the entity's state on the server.
+That may be a problem for your application.
+You might prefer that the entity be restored to a known server state,
+such as the state of the entity when it was last queried or successfully saved.
+
+If the _ChangeTracker_ had captured that state in the `entityCollection.originalValues` _before_ the entity was changed in cache,
+the app could tell the tracker to revert the entity to that state when it
+sees an HTTP save error.
+
+### ChangeTracker _MetaReducers_ 
+
+The _ngrx_data_ library has optional [_MetaReducers_](entity-reducer.md#collection-meta-reducers)
+that can track the entity state before an optimistic save and revert the entity
+to it state when last queried or successfully saved.
+
+These MetaReducers are included by default.
+
+>You can remove or replace them during `NgrxDataModule` configuration.
+
+_More on all of this soon_

--- a/docs/entity-collection.md
+++ b/docs/entity-collection.md
@@ -1,0 +1,18 @@
+# Entity Collection
+
+The _ngrx-data_ library maintains a _cache_ (`EntityCache`) of
+_entity collections_ for each _entity type_ in the _ngrx store_.
+
+An _entity_collection_  implements the [`EntityCollection<T>` interface](../lib/src/interfaces.ts).
+
+| Property   | Meaning                                  |
+| ---------- |------------------------------------------|
+| `ids`      | Primary key values in default sort order |
+| `entities` | Map of primary key to entity data values |
+| `filter`   | The user's filtering criteria            |
+| `loaded`   | Whether collection was filled by QueryAll; forced false after clear |
+| `loading`  | Whether currently waiting for query results to arrive from the server |
+| `originalValues` | When [change-tracking](change-tracker.md) is enabled, the original values of unsaved entities |
+
+You can extend an entity types with _additional properties_ via 
+[entity metadata](entity-metadata.md#additional-collection-state).

--- a/docs/entity-dataservice.md
+++ b/docs/entity-dataservice.md
@@ -76,31 +76,24 @@ The [_Entity Metadata_](entity-metadata.md#plurals) guide
 explains how to configure the default `Pluralizer` .
 
 <a name="configuration"></a>
-## Configure the service
+### Configure the _DefaultDataService_
 
 The collection-level data services construct their own URLs for HTTP calls. They typically rely on shared configuration information such as the root of every resource URL.
 
 The shared configuration values are almost always specific to the application and may vary according the runtime environment.
 
-The _ngrx-data_ library defines an [`EntityDataServiceConfig` class](../lib/src/entity-data.service.ts) for conveying shared configuration to an entity collection data service.
+The _ngrx-data_ library defines a [`DefaultDataServiceConfig` class](../lib/src/default-data.service.ts) for conveying shared configuration to an entity collection data service.
 
-The most important configuration property, `api`, returns the _root_ of every web api URL, the parts that come before the entity resource name.
+The most important configuration property, `root`, returns the _root_ of every web api URL, the parts that come before the entity resource name.
 
-The default value is `'api'`, which results in URLs such as `api/heroes`.
+For a `DefaultDataService<T>`, the default value is `'api'`, which results in URLs such as `api/heroes`.
 
-The `timeout` property sets the maximum time (in ms) before the _ng-lib_ persistence operation abandons hope of receiving a server reply and cancels the operation. The default value is `0`, which means the 
+The `timeout` property sets the maximum time (in ms) before the _ng-lib_ persistence operation abandons hope of receiving a server reply and cancels the operation. The default value is `0`, which means that requests do not timeout.
+
+The `delete404OK` flag tells the data service what to do if the server responds to a DELETE request with a `404 - Not Found`.
+
+In general, not finding the resource to delete is harmless and
+you can save yourself the headache of ignoring a DELETE 404 error
+by setting this flag to `true`, which is the default for the `DefaultDataService<T>`.
 
 When running a demo app locally, the server may respond more quickly than it will in production. You can simulate real-world by setting the `getDelay` and `saveDelay` properties.
-
-### Extend _EntityDataServiceConfig_
-
-The `EntityDataServiceConfig` class is designed to match the needs of the `DefaultDataService`. 
-
-You could extend it with additional properties in a derived class and override the `EntityDataServiceConfig` provider like this.
-
-```javascript
-NgrxDataModule.forRoot({
-  entityDataServiceConfig: myDataServiceConfig,
-  ...
-})
-```

--- a/docs/entity-metadata.md
+++ b/docs/entity-metadata.md
@@ -168,18 +168,11 @@ Run the demo app and try changing existing hero names or adding new heroes.
 
 Your app can call the `selectKey` selector to see the collection's `ids` property, which returns an array of the collection's primary key values in sorted order.
 
-<a name=additionalcollectionstate></a>
+<a name=additional-collection-state></a>
 ### _additionalCollectionState_
 
-Each _ngrx-data_ entity collection in the the store has these predefined properties.
-
-| Property   | Meaning                                  |
-| ---------- |------------------------------------------|
-| `ids`      | Primary key values in default sort order |
-| `entities` | Map of primary key to entity data values |
-| `filter`   | The user's filtering criteria            |
-| `loaded`   | Whether collection was filled by QueryAll; forced false after clear |
-| `loading`  | Whether currently waiting for query results to arrive from the server |
+Each _ngrx-data_ entity collection in the the store has
+[predefined properties](entity-collection.md).
 
 You can add your own collection properties by setting the `additionalCollectionState` property to an object with those custom collection properties.
 

--- a/docs/extension-points.md
+++ b/docs/extension-points.md
@@ -34,6 +34,21 @@ For example, querying all heroes results in the entity type, `QUERY_ALL [Hero]`.
 If you don't like that approach you can replace the `formatActionType()` method with a generator that produces action type names that are more to your liking.
 The ngrx-data library doesn't make decisions based on the `Action.type`.
 
+## Custom _EntityDispatcher_
+
+### Change the default save strategy
+
+The dispatcher's `add()`, `update()`, `delete()` methods dispatch
+_optimistic_ or _pessimistic_ save actions based on settings in the `EntityDispatcherOptions`.
+
+These options come from the `EntityDispatcherFactory` that creates the dispatcher.
+This factory gets the options from the entity's metadata.
+But where the metadata lack options, the factory relies on its `defaultDispatcherOptions`.
+
+You can set these default options directly by injecting the `EntityDispatcherFactory`
+and re-setting `defaultDispatcherOptions` _before_ creating dispatchers
+(or creating an `EntityService` which creates a dispatcher).
+
 ## Custom _effects_
 
 The _ngrx-data_ library has one ngrx `@Effect`, the `EntityEffects` class.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -77,16 +77,18 @@ Now register the Web API configuration, metadata, and plurals with the `ngrx-dat
 
 import { pluralNames, entityMetadata } from './entity-metadata';
 
-// Set 'api', the root URL of the remote Web API.
-const entityDataServiceConfig: EntityDataServiceConfig = { api: 'api'};
+// Set 'root', the root URL of the remote Web API.
+const defaultDataServiceConfig: DefaultDataServiceConfig = { root: 'api' };
 
 @NgModule({
   imports: [
     NgrxDataModule.forRoot({
-      entityDataServiceConfig,
       entityMetadata: entityMetadata,
       pluralNames: pluralNames
     })
+  ],
+  providers: [
+    { provide: DefaultDataServiceConfig, useValue: defaultDataServiceConfig }
   ]
 })
 export class EntityStoreModule {}

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -162,43 +162,14 @@ If your web API supports such operations,
 you might follow the _ngrx-data_ patterns
 while adding your own entity actions and _ngrx effects_ for these operations.
 
-## Optimistic delete; no compensation
-
-When saving, the _ngrx-data_ `EntityCollectionReducer<T>` deletes the entity from cache _before_ sending a delete request to the server.
-
-This is called an _optimistic delete_ because _ngrx-data_ is optimistic about the prospects for a successful delete.
-
-If the server rejects the save or the save times-out, the reducer does not compensate by restoring the deleted entity to cache.
-
-A future version of _ngrx-data_ could restore the deleted entity when the server delete request fails.
-A future version might also offer a _pessimistic delete_ option.
-
-## Pessimistic add/update
-
-When processing the `SAVE_ADD` or `SAVE_UPDATE` actions,
-The `EntityCollectionReducer` does not immediately add a new entity to the collection or update an existing entity in the collection.
-
-It waits for the `SAVE_ADD_SUCCESS` or `SAVE_UPDATE_SUCCESS` actions, which indicate that the server processed the requests successfully.
-
-This a _pessimistic_ policy because _ngrx-data_ 
-would rather guard against the risk of failure than
-benefit from the (stronger) likelihood of success.
-
-_Ngrx-data_ takes this approach because it does not have the ability to reverse the add or update in cache
-it the request fails.
-
-The delay might be noticeable if the connection to the server is very slow.
-
-A future version of _ngrx-data_ could offer _optimistic_ add and update with compensation for server request failures.
-
 ## No explicit _SAVE_UPSERT_
 
 The default `EntityEffects` supports saving a new or existing entity but does not have an explicit
 SAVE_UPSERT action that would _official_ save
 an entity which might be either new or existing.
 
-You may be able to add a new entity with `SAVE_UPDATE`,
-because the `EntityCollectionReducer` implements `SAVE_UPDATE_SUCCESS` 
+You may be able to add a new entity with `SAVE_UPDATE` or `SAVE_UPDATE_OPTIMISTIC`,
+because the `EntityCollectionReducer` implements these actions 
 by calling the collection `upsertOne()` method.
 
 Do this _only_ if your server supports _upsert-with-PUT_ requests.

--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -1,9 +1,26 @@
 ## Angular ngrx-data library ChangeLog
-<a name="1.0.0-alpha.7"></a>
-# release 1.0.0-alpha.7 (NOT YET. IN MASTER)
 
-* SAVE_UPDATE_SUCCESS calls upsert so can do the equivalent of a SAVE_UPSERT by dispatching a SAVE_UPDATE with a new entity.
+<a name="1.0.0-alpha.7"></a>
+# release 1.0.0-alpha.7 (2018-02-19)
+
+* Support both optimistic and pessimistic save strategies
+* New `EntityMetadata.entityDispatcherOptions` enables setting the strategy _per collection_.
+* Add `EntityChangeTracker`
+* `SAVE_UPDATE` processing calls _upsert_ so can do the equivalent of a `SAVE_UPSERT` by dispatching a `SAVE_UPDATE` with a new entity.
 Do this _only_ if your server supports upsert requests.
+* `EntityCollection<T>` interface moved to `./interfaces.ts`
+* `EntityDataServiceConfig` is now the `DefaultDataServiceConfig` and moved to `default-data.service.ts`
+* `NgrxDataModule.forRoot` no longer takes an `EntityDataServiceConfig`. Instead you should provide the `DefaultDataServiceConfig` in your own module providers.
+
+### Breaking Changes
+
+* The transition from `EntityDataServiceConfig` to `DefaultDataServiceConfig` is
+a breaking change. 
+See the ["_Introduction_"](https://github.com/johnpapa/angular-ngrx-data/blob/master/docs/introduction.md)
+document for an example.
+
+* The previous save operations did not revert entities that failed to save.
+The next version will revert those entities after a save error.
 
 <a name="1.0.0-alpha.6"></a>
 # release 1.0.0-alpha.6 (2018-02-14)

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngrx-data",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "repository": "https://github.com/johnpapa/angular-ngrx-data.git",
   "license": "MIT",
   "peerDependencies": {

--- a/lib/src/entity-action-guard.spec.ts
+++ b/lib/src/entity-action-guard.spec.ts
@@ -1,0 +1,8 @@
+import { EntityAction } from './entity.actions';
+import { IdSelector, Update } from './ngrx-entity-models';
+
+import { EntityActionGuard } from './entity-action-guard';
+
+describe('EntityActionGuard', () => {
+  // TODO: write some tests
+});

--- a/lib/src/entity-action-guard.ts
+++ b/lib/src/entity-action-guard.ts
@@ -1,0 +1,55 @@
+import { EntityAction } from './entity.actions';
+import { IdSelector, Update } from './ngrx-entity-models';
+
+export class EntityActionGuard<T> {
+  constructor(
+    private entityName: string,
+    private selectId: IdSelector<T>
+  ) { }
+
+  mustBeOne(changes: any[], entityOp: string, exactlyOne: boolean) {
+    if (exactlyOne && changes.length !== 1) {
+      const errorMsg = `${entityOp} payload should be one ${this.entityName}.`;
+      throw new Error(errorMsg);
+    }
+  }
+
+  mustBeEntities(entities: T[], entityOp: string, exactlyOne = false) {
+    this.mustBeOne(entities, entityOp, exactlyOne);
+    entities.forEach((entity, i) => {
+      const id = this.selectId(entity);
+      if (id == null) {
+        const reason = 'is not an entity with a valid key (id)'
+        this.onError(entities, i, entityOp, reason);
+      }
+    })
+  }
+
+  mustBeIds(ids: number | string | (number | string)[], entityOp: string, exactlyOne = false) {
+    const changes = Array.isArray(ids) ? ids : [ids];
+    this.mustBeOne(changes, entityOp, exactlyOne);
+    changes.forEach((id, i) => {
+      if (typeof id === 'number' || typeof id === 'string') { return; }
+      const reason = 'is not a valid primary key (id)'
+      this.onError(changes, i, entityOp, reason);
+    })
+  }
+
+  mustBeUpdates(updates: Update<T>[], entityOp: string, exactlyOne = false) {
+    const changes = Array.isArray(updates) ? updates : [updates];
+    this.mustBeOne(changes, entityOp, exactlyOne);
+    changes.forEach((up, i) => {
+      // An Update<T> has `id` and `changes` properties
+      if (up.id == null || up.changes == null) {
+        const reason = `is not an Update<${this.entityName}> with a valid id`
+        this.onError(changes, i, entityOp, reason);
+      }
+    });
+  }
+
+  private onError(changes: any[], index: number, entityOp: string, reason: string) {
+    const itemMsg = changes.length > 1 ? `Item ${index} in ` : ''
+    const errorMsg = `${itemMsg}${this.entityName} ${entityOp} payload ${reason}.`;
+    throw new Error(errorMsg);
+  }
+}

--- a/lib/src/entity-change-tracker.spec.ts
+++ b/lib/src/entity-change-tracker.spec.ts
@@ -1,0 +1,290 @@
+import { EntityAdapter, createEntityAdapter } from '@ngrx/entity';
+
+import { EntityCollection } from './interfaces';
+import { createEmptyEntityCollection } from './entity-collection-creator';
+import { IdSelector, Update } from './ngrx-entity-models';
+
+import { EntityChangeTracker } from './entity-change-tracker';
+
+interface Hero {
+  id: number;
+  name: string;
+  power?: string;
+}
+
+function sortByName(a: { name: string }, b: { name: string }): number {
+  return a.name.localeCompare(b.name);
+}
+
+const adapter: EntityAdapter<Hero> = createEntityAdapter<Hero>({
+  sortComparer: sortByName
+});
+
+describe('EntityChangeTracker', () => {
+
+  let origCollection: EntityCollection<Hero>;
+  let collection: EntityCollection<Hero>;
+
+  let tracker: EntityChangeTracker<Hero>;
+  beforeEach(() => {
+    tracker = new EntityChangeTracker('Hero', adapter);
+
+    origCollection = createEmptyEntityCollection<Hero>();
+    origCollection.entities = {
+      1: {id: 1, name: 'Alice', power: 'Strong'},
+      2: {id: 2, name: 'Gail', power: 'Loud'},
+      7: {id: 7, name: 'Bob', power: 'Swift'},
+    }
+    origCollection.ids = [1, 7, 2];
+  });
+
+  describe('#addToTracker', () => {
+
+    it('should return a new collection after adding an entity', () => {
+      collection = tracker.addToTracker(origCollection, [1]);
+      expect(collection).not.toBe(origCollection);
+    });
+
+    it('can add tracking of existing entity by id', () => {
+      collection = tracker.addToTracker(origCollection, [1]);
+      expect(collection.originalValues[1]).toBe(collection.entities[1]);
+    });
+
+    it('can add tracking of existing entity by entity', () => {
+      const entity = origCollection.entities[1];
+      collection = tracker.addToTracker(origCollection, [entity]);
+      expect(collection.originalValues[1]).toBe(entity);
+    });
+
+    it('can add tracking of existing entity by Update<T>', () => {
+      const entity = origCollection.entities[1];
+      const update = { id: 1, changes: entity };
+      collection = tracker.addToTracker(origCollection, [update]);
+      expect(collection.originalValues[1]).toBe(entity);
+    });
+
+    it('can add tracking of several existing entities', () => {
+      const entity = origCollection.entities[1];
+      const update = { id: 2, changes: origCollection.entities[2] };
+
+      collection = tracker.addToTracker(origCollection,
+         [7, entity, update]);
+
+      const originals = collection.originalValues;
+
+      expect(Object.keys(originals)).toEqual(['1', '2', '7']);
+      expect(originals[1]).toBe(entity);
+      expect(originals[2]).toBe(update.changes);
+      expect(originals[7]).toBe(origCollection.entities[7]);
+    });
+
+    it('should return a new collection when it updates originalValues', () => {
+      collection = tracker.addToTracker(origCollection, [1]);
+      expect(collection).not.toBe(origCollection);
+    });
+
+    it('tracked entity should be undefined when not in cache (indicates revertable "add")', () => {
+      collection = tracker.addToTracker(origCollection, [42]);
+      expectIsTracked(42);
+    });
+
+    it('should preserve first tracked original when tracked a second time', () => {
+      const origHero = origCollection.entities[1];
+      collection = tracker.addToTracker(origCollection, [1]);
+
+      // change the cached hero id:1
+      collection = adapter.updateOne({id: 1, changes: {name: 'xxx'}}, collection);
+      expect(collection.entities[1].name).toBe('xxx', 'name changed in cache');
+
+      // second tracking of id:1 which has changed; should be ignored.
+      collection = tracker.addToTracker(origCollection, [1]);
+      expect(collection.originalValues[1]).toBe(origHero, 'original preserved');
+    });
+  });
+
+  describe('#revert', () => {
+
+    it('should revert an added entity', () => {
+      // track entities 1 & 7
+      collection = tracker.addToTracker(origCollection, [7, 1]);
+
+      // Track it BEFORE adding to the collection
+      const entity = { id: 42, name: 'Smokey', power: 'Invisible'};
+      collection = tracker.addToTracker(collection, [entity])
+      expectIsTracked(42);
+      expect(collection.originalValues[42]).toBeUndefined('id:42 represented by undefined');
+
+      // Now add id:42
+      collection = adapter.addMany([entity], collection);
+      expect(collection.ids).toEqual([1, 7, 2, 42], 'added id:42');
+
+      collection = tracker.revert(collection, [42]);
+
+      expect(collection.ids).toEqual([1, 7, 2], 'restored ids, in sort order');
+      expectIsNotTracked(42);
+      expectIsTracked(1);
+    });
+
+    it('should NOT revert added entity when tracked after add', () => {
+      // track entities 1 & 7
+      collection = tracker.addToTracker(origCollection, [7, 1]);
+
+      // Add before track. Probably not what you intended!
+      const entity = { id: 42, name: 'Smokey', power: 'Invisible'};
+      collection = adapter.addMany([entity], collection);
+
+      // Add to tracker AFTER adding to the collection
+      collection = tracker.addToTracker(collection, [entity])
+      expect(collection.originalValues[42]).toBe(entity, 'tracking added entity');
+
+      expect(collection.ids).toEqual([1, 7, 2, 42], 'added id:42');
+
+      collection = tracker.revert(collection, [42]);
+
+      // Not what you intended
+      expect(collection.ids).toEqual([1, 7, 2, 42], 'ids are the same');
+      expect(collection.entities[42]).toBe(entity, 'added entity still there');
+      expectIsNotTracked(42); // does stop tracking it
+      expectIsTracked(1);
+    });
+
+    it('should revert a deleted entity', () => {
+      // track entities 1 & 7
+      collection = tracker.addToTracker(origCollection, [7, 1]);
+      const entity = origCollection.entities[7];
+
+      // "delete" id:7
+      collection = adapter.removeMany([7], collection);
+      expect(collection.ids).toEqual([ 1 , 2], 'removed id:7');
+
+      collection = tracker.revert(collection, [7]);
+
+      expect(collection.ids).toEqual([1, 7, 2], 'restored ids, in sort order');
+      expect(collection.entities[7]).toBe(entity, 'id:7 entity was restored');
+      expectIsNotTracked(7);
+      expectIsTracked(1);
+    });
+
+    it('should revert an updated entity', () => {
+      // track entities 1 & 7
+      collection = tracker.addToTracker(origCollection, [7, 1]);
+
+      // update id:7
+      const entity = origCollection.entities[7];
+      const update = { id: 7, changes: { power: 'test-power' } };
+      collection = adapter.updateOne(update, collection);
+
+      expect(collection.entities[7].power).toBe('test-power', 'updated power');
+
+      collection = tracker.revert(collection, [7]);
+
+      expect(collection.entities[7]).toBe(entity, 'id:7 entity was restored');
+      expect(collection.entities[7].power).toBe(entity.power, 'id:7 has same power');
+      expectIsNotTracked(7);
+      expectIsTracked(1);
+    });
+
+    it('should not revert an untracked, updated entity', () => {
+      const update = { id: 7, changes: { id: 7, power: 'test-power' } };
+
+      // not tracked before update
+      collection = adapter.updateOne(update, origCollection);
+      expect(collection.entities[7].power).toBe('test-power', 'updated power');
+
+      collection = tracker.revert(collection, [7]);
+      expect(collection.entities[7].power).toBe('test-power', 'did not revert power');
+      expectIsNotTracked(7);
+    });
+
+    it('should revert several entities', () => {
+      collection = tracker.addToTracker(origCollection, [1, 2, 7, 42]);
+
+      const entity = { id: 42, name: 'Smokey', power: 'Invisible'};
+      const entity7 = collection.entities[7];
+      const update = { id: 7, changes: {id: 7, power: 'test-power' } };
+
+      collection = adapter.addMany([entity], collection);
+      collection = adapter.removeMany([1, 2], collection);
+      collection = adapter.updateOne(update, collection);
+
+      // revert all but id:2
+      collection = tracker.revert(collection, [1, 7, 42]);
+
+      // restored deleted id:1 but not id:2; removed added id:42
+      expect(collection.ids).toEqual([1, 7]);
+      expect(collection.entities[7]).toBe(entity7);
+      expect(Object.keys(collection.originalValues)).toEqual(['2'], 'only id:2 still tracked');
+    });
+
+    it('should return original collection when none of the entities are tracked', () => {
+      collection = tracker.revert(origCollection, [1, 2, 7]);
+      expect(collection).toBe(origCollection);
+    });
+
+    it('should return original collection when asked to revert no entities', () => {
+      const trackingCollection = tracker.addToTracker(origCollection, [1, 7, 42]);
+      collection = tracker.revert(trackingCollection, []);
+      expect(collection).toBe(trackingCollection);
+    })
+
+    it('cannot (yet) revert an update that changes the primary key', () => {
+      collection = tracker.addToTracker(origCollection, [1]);
+      const entity = collection.entities[1];
+      const update = { id: 1, changes: { id: 42, name: 'test-name' }};
+
+      collection = adapter.updateOne(update, collection);
+      expect(collection.ids).toEqual([7, 2, 42], 'ids after update');
+
+      // won't do it properly, even if you provide both ids
+      collection = tracker.revert(collection, [1, 42]);
+
+      // Both 1 and 42 are in cache!
+      expect(collection.ids).toEqual([1, 7, 2, 42], 'ids improperly restored');
+      expect(collection.ids).not.toEqual([1, 7, 2], 'ids if reverted correctly');
+
+      expectIsNotTracked(1);
+      expectIsNotTracked(42);
+    });
+  });
+
+  describe('#revertAll', () => {
+    it('should revert all tracked entity changes', () => {
+      collection = tracker.addToTracker(origCollection, [1, 2, 7, 42]);
+
+      const entity = { id: 42, name: 'Smokey', power: 'Invisible'};
+      const entity7 = collection.entities[7];
+      const update = { id: 7, changes: {id: 7, power: 'test-power' } };
+
+      collection = adapter.addMany([entity], collection);
+      collection = adapter.removeMany([1, 2], collection);
+      collection = adapter.updateOne(update, collection);
+
+      // revert all
+      collection = tracker.revertAll(collection);
+
+      expect(collection.ids).toEqual([1, 7, 2], 'ids after revert');
+      expect(collection.entities[7]).toBe(entity7);
+      expect(collection.originalValues).toEqual({});
+    });
+
+    it('should return original collection when there are no tracked entities', () => {
+      collection = tracker.revertAll(origCollection);
+      expect(collection).toBe(origCollection);
+    });
+  });
+
+  describe('#removeFromTracker', () => {
+    // TBD
+  });
+
+  /// test helpers ///
+  function expectIsTracked(id: (number | string)) {
+    expect(collection.originalValues.hasOwnProperty(id))
+      .toBe(true, `hero ${id} is in originalValues`);
+  }
+
+  function expectIsNotTracked(id: (number | string)) {
+    expect(collection.originalValues.hasOwnProperty(id))
+      .toBe(false, `hero ${id} is in originalValues`);
+  }
+});

--- a/lib/src/entity-change-tracker.ts
+++ b/lib/src/entity-change-tracker.ts
@@ -1,0 +1,105 @@
+import { EntityAdapter, EntityState } from '@ngrx/entity';
+
+import { defaultSelectId } from './utils';
+import { EntityCollection } from './interfaces';
+import { IdSelector, Update } from './ngrx-entity-models';
+
+// Methods needed by EntityChangeTracker to mutate the collection
+// The minimum subset of the @ngrx/entity EntityAdapter methods.
+export interface CollectionMutator<T> {
+  addMany<S extends EntityState<T>>(entities: T[], state: S): S;
+  removeMany<S extends EntityState<T>>(keys: string[], state: S): S;
+}
+
+export class EntityChangeTracker<T> {
+  constructor(
+    public name: string,
+    private mutator: CollectionMutator<T>,
+    private selectId?: IdSelector<T>) {
+    /** Extract the primary key (id); default to `id` */
+    this.selectId = selectId || defaultSelectId;
+  }
+
+  /**
+   * Add entities to tracker by adding them to the collection's originalValues.
+   * @param collection Source entity collection
+   * @param idsSource  Array of id sources which could be an id,
+   * an entity or an entity update
+   */
+  addToTracker(collection: EntityCollection<T>,
+    idsSource: (number | string | T | Update<T>)[]): EntityCollection<T> {
+    let ids: (number | string)[] = (idsSource || []).map(
+      (source: any) => typeof source === 'object' ?
+        source.id && source.changes ? source.id : this.selectId(source) :
+        source
+    );
+
+    let originalValues = collection.originalValues;
+
+    // add only the ids that aren't currently tracked
+    ids = ids.filter(id => !originalValues.hasOwnProperty(id))
+    if (ids.length === 0) {
+      return collection;
+    }
+
+    const entities = collection.entities;
+    originalValues = { ...originalValues }; // clone it
+
+    // when entities[id] === undefined, it's a revertable "add"
+    ids.forEach(id => originalValues[id] = entities[id]);
+    return { ...collection, originalValues };
+  }
+
+  /**
+   * Remove given entities from tracker by removing them from original values.
+   * Those entities can no longer be reverted to their original values.
+   * @param collection Entity collection with originalValues
+   * @param ids Ids of entities whose original values should be removed.
+   */
+  removeFromTracker(collection: EntityCollection<T>, ids?: (number | string)[])
+  : EntityCollection<T> {
+    let originalValues = collection.originalValues;
+    ids = (ids || []).filter(id => originalValues.hasOwnProperty(id));
+    if (ids.length === 0) {
+      return collection;
+    }
+    originalValues = { ...originalValues }; // clone it
+    ids.forEach(id => delete originalValues[id])
+    return { ...collection, originalValues };
+  }
+
+  /**
+   * Revert entities with given ids to their original values.
+   * @param collection Source entity collection
+   * @param ids Ids of entities to revert to original values
+   */
+  revert(collection: EntityCollection<T>, ids: (number|string)[]): EntityCollection<T> {
+    const newCollection = this._revertCore(collection, ids);
+    return newCollection === collection ? collection : this.removeFromTracker(newCollection, ids);
+  }
+
+  /**
+   * Revert every entity that is tracked in originalValues
+   * @param collection Source entity collection
+   */
+  revertAll(collection: EntityCollection<T>) {
+    const ids = Object.keys(collection.originalValues);
+    return ids.length === 0 ? collection :
+      {...this._revertCore(collection, ids), originalValues: {}};
+  }
+
+  private _revertCore(collection: EntityCollection<T>, ids: (number|string)[]): EntityCollection<T> {
+    const originalValues = collection.originalValues;
+    ids = (ids || []).filter(id => originalValues.hasOwnProperty(id));
+    if (ids.length === 0) {
+      return collection;
+    }
+
+    // TODO: consider a more efficient approach than removing and adding
+    collection = this.mutator.removeMany(<any[]>ids, collection);
+
+    // `falsey` original entity indicates an added entity that should be removed
+    const originals = ids.map(id => originalValues[id]).filter(o => !!o);
+    return originals.length === 0 ? collection : this.mutator.addMany(originals, collection);
+  }
+}

--- a/lib/src/entity-collection-creator.spec.ts
+++ b/lib/src/entity-collection-creator.spec.ts
@@ -1,4 +1,5 @@
-import { createEntityDefinition, EntityCollection, EntityDefinition } from './entity-definition';
+import { createEntityDefinition, EntityDefinition } from './entity-definition';
+import { EntityCollection } from './interfaces';
 import { EntityDefinitionService } from './entity-definition.service';
 import { EntityCollectionCreator } from './entity-collection-creator';
 import { EntityMetadata } from './entity-metadata';

--- a/lib/src/entity-collection-creator.ts
+++ b/lib/src/entity-collection-creator.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 
-import { EntityCollection } from './entity-definition';
+import { EntityCollection } from './interfaces';
 import { EntityDefinitionService } from './entity-definition.service';
 
 @Injectable()
@@ -20,12 +20,13 @@ export class EntityCollectionCreator {
   }
 }
 
-function createEmptyEntityCollection<T>(): EntityCollection<T> {
+export function createEmptyEntityCollection<T>(): EntityCollection<T> {
   return  {
     ids: [],
     entities: {},
     filter: undefined,
     loaded: false,
-    loading: false
+    loading: false,
+    originalValues: {}
   } as EntityCollection<T>;
 }

--- a/lib/src/entity-data.service.spec.ts
+++ b/lib/src/entity-data.service.spec.ts
@@ -11,7 +11,7 @@ import { HttpUrlGenerator } from './http-url-generator'
 import { DefaultDataService, DefaultDataServiceFactory } from './default-data.service';
 
 import { EntityDataService } from './entity-data.service';
-import { EntityCollectionDataService, EntityDataServiceConfig, QueryParams } from './interfaces';
+import { EntityCollectionDataService, QueryParams } from './interfaces';
 import { Update } from './ngrx-entity-models';
 
 // region Test Helpers
@@ -82,7 +82,6 @@ class TestHttpUrlGenerator implements HttpUrlGenerator {
 
 ///// Tests begin ////
 describe('EntityDataService', () => {
-  const config = {api: 'api'};
   const nullHttp = {};
   let entityDataService: EntityDataService;
 
@@ -92,7 +91,6 @@ describe('EntityDataService', () => {
       providers: [
         DefaultDataServiceFactory,
         EntityDataService,
-        { provide: EntityDataServiceConfig, useValue: config},
         { provide: HttpClient, useValue: nullHttp },
         { provide: HttpUrlGenerator, useClass: TestHttpUrlGenerator }
       ]

--- a/lib/src/entity-definition.spec.ts
+++ b/lib/src/entity-definition.spec.ts
@@ -45,7 +45,8 @@ describe('EntityDefinition', () => {
         entities: {},
         filter: '',
         loaded: false,
-        loading: false
+        loading: false,
+        originalValues: {}
       })
     });
 
@@ -60,6 +61,7 @@ describe('EntityDefinition', () => {
         filter: '',
         loaded: false,
         loading: false,
+        originalValues: {},
         foo: 'foo'
       })
     });
@@ -80,6 +82,21 @@ describe('EntityDefinition', () => {
       delete heroMetadata.sortComparer;
       const def = createEntityDefinition(heroMetadata);
       expect(def.metadata.sortComparer).toBe(false);
+    });
+
+    it('sets `entityDispatchOptions to {} if not in metadata', () => {
+      const def = createEntityDefinition(heroMetadata);
+      expect(def.entityDispatcherOptions).toEqual({});
+    });
+
+    it('passes `metadata.entityDispatchOptions` thru', () => {
+      const options =  {
+        optimisticAdd: false,
+        optimisticUpdate: false,
+      };
+      heroMetadata.entityDispatcherOptions = options;
+      const def = createEntityDefinition(heroMetadata);
+      expect(def.entityDispatcherOptions).toBe(options);
     });
 
     it('creates expected selectors', () => {

--- a/lib/src/entity-metadata.ts
+++ b/lib/src/entity-metadata.ts
@@ -1,5 +1,5 @@
+import { EntityDispatcherOptions } from './interfaces';
 import { EntityFilterFn } from './entity-filters';
-
 import { IdSelector, Comparer } from './ngrx-entity-models';
 
 export interface EntityMetadataMap {
@@ -8,6 +8,7 @@ export interface EntityMetadataMap {
 
 export interface EntityMetadata<T = any, S extends object = {}> {
   entityName: string;
+  entityDispatcherOptions?: Partial<EntityDispatcherOptions>,
   filterFn?: EntityFilterFn<T>;
   selectId?: IdSelector<T>;
   sortComparer?: false | Comparer<T>;

--- a/lib/src/entity.effects.spec.ts
+++ b/lib/src/entity.effects.spec.ts
@@ -64,8 +64,12 @@ describe('EntityEffects (normal testing)', () => {
 
   function expectCompletion(completion: EntityAction) {
     effects.persist$.subscribe(
-      result => expect(result).toEqual(completion),
-      fail
+      result => {
+        expect(result).toEqual(completion)
+      },
+      e => {
+        fail(e);
+      }
     )
   }
 
@@ -233,6 +237,84 @@ describe('EntityEffects (normal testing)', () => {
   it('should return a SAVE_UPDATE_ERROR when service fails', () => {
     const update = { id: 1, changes: {id: 1, name: 'A' }} as Update<Hero>;
     const action = entityActionFactory.create('Hero', EntityOp.SAVE_UPDATE, update);
+    const httpError = { error: new Error('Test Failure'), status: 501 };
+    const completion = makeEntityErrorCompletion(action, 'PUT', httpError)
+    const error = completion.payload.error;
+
+    actions$.stream = of(action);
+    const response = new ErrorObservable(error);
+    testEntityDataService.dataServiceSpy.update.and.returnValue(response);
+
+    expectCompletion(completion);
+  });
+
+  it('should return a SAVE_ADD_OPTIMISTIC_SUCCESS with the hero on success', () => {
+    const hero = { id: 1, name: 'A' } as Hero;
+
+    const action = entityActionFactory.create('Hero', EntityOp.SAVE_ADD_OPTIMISTIC, hero);
+    const completion = entityActionFactory.create('Hero', EntityOp.SAVE_ADD_OPTIMISTIC_SUCCESS, hero);
+
+    actions$.stream = of(action);
+    const response = of(hero);
+    testEntityDataService.dataServiceSpy.add.and.returnValue(response);
+
+    expectCompletion(completion);
+  });
+
+  it('should return a SAVE_ADD_OPTIMISTIC_ERROR when service fails', () => {
+    const hero = { id: 1, name: 'A' } as Hero;
+    const action = entityActionFactory.create('Hero', EntityOp.SAVE_ADD_OPTIMISTIC, hero);
+    const httpError = { error: new Error('Test Failure'), status: 501 };
+    const completion = makeEntityErrorCompletion(action, 'PUT', httpError)
+    const error = completion.payload.error;
+
+    actions$.stream = of(action);
+    const response = new ErrorObservable(error);
+    testEntityDataService.dataServiceSpy.add.and.returnValue(response);
+
+    expectCompletion(completion);
+  });
+
+  it('should return a SAVE_DELETE_OPTIMISTIC_SUCCESS on success', () => {
+    const action = entityActionFactory.create('Hero', EntityOp.SAVE_DELETE_OPTIMISTIC, 42);
+    const completion = entityActionFactory.create('Hero', EntityOp.SAVE_DELETE_OPTIMISTIC_SUCCESS);
+
+    actions$.stream = of(action);
+    const response = of(undefined);
+    testEntityDataService.dataServiceSpy.delete.and.returnValue(response);
+
+    expectCompletion(completion);
+  });
+
+  it('should return a SAVE_DELETE_OPTIMISTIC_ERROR when service fails', () => {
+    const action = entityActionFactory.create('Hero', EntityOp.SAVE_DELETE_OPTIMISTIC, 42);
+    const httpError = { error: new Error('Test Failure'), status: 501 };
+    const completion = makeEntityErrorCompletion(action, 'DELETE', httpError)
+    const error = completion.payload.error;
+
+    actions$.stream = of(action);
+    const response = new ErrorObservable(error);
+    testEntityDataService.dataServiceSpy.delete.and.returnValue(response);
+
+    expectCompletion(completion);
+  });
+
+  it('should return a SAVE_UPDATE_OPTIMISTIC_SUCCESS with the hero on success', () => {
+    const update = { id: 1, changes: {id: 1, name: 'A' }} as Update<Hero>;
+
+    const action = entityActionFactory.create('Hero', EntityOp.SAVE_UPDATE_OPTIMISTIC, update);
+    const completion = entityActionFactory.create('Hero', EntityOp.SAVE_UPDATE_OPTIMISTIC_SUCCESS, update);
+
+    actions$.stream = of(action);
+    const response = of(update);
+    testEntityDataService.dataServiceSpy.update.and.returnValue(response);
+
+    expectCompletion(completion);
+  });
+
+  it('should return a SAVE_UPDATE_OPTIMISTIC_ERROR when service fails', () => {
+    const update = { id: 1, changes: {id: 1, name: 'A' }} as Update<Hero>;
+    const action = entityActionFactory.create('Hero', EntityOp.SAVE_UPDATE_OPTIMISTIC, update);
     const httpError = { error: new Error('Test Failure'), status: 501 };
     const completion = makeEntityErrorCompletion(action, 'PUT', httpError)
     const error = completion.payload.error;

--- a/lib/src/entity.effects.ts
+++ b/lib/src/entity.effects.ts
@@ -18,7 +18,10 @@ const persistOps: EntityOp[] = [
   EntityOp.QUERY_MANY,
   EntityOp.SAVE_ADD,
   EntityOp.SAVE_DELETE,
-  EntityOp.SAVE_UPDATE
+  EntityOp.SAVE_UPDATE,
+  EntityOp.SAVE_ADD_OPTIMISTIC,
+  EntityOp.SAVE_DELETE_OPTIMISTIC,
+  EntityOp.SAVE_UPDATE_OPTIMISTIC
 ];
 
 @Injectable()
@@ -35,6 +38,9 @@ export class EntityEffects {
   ) {}
 
   private persist(action: EntityAction) {
+    if (action.error) {
+      return this.resultHandler.handleError(action)(action.error);
+    }
     try {
       return this.callDataService(action).pipe(
         map(this.resultHandler.handleSuccess(action)),
@@ -57,12 +63,15 @@ export class EntityEffects {
       case EntityOp.QUERY_MANY: {
         return service.getWithQuery(action.payload);
       }
+      case EntityOp.SAVE_ADD_OPTIMISTIC:
       case EntityOp.SAVE_ADD: {
         return service.add(action.payload);
       }
+      case EntityOp.SAVE_DELETE_OPTIMISTIC:
       case EntityOp.SAVE_DELETE: {
         return service.delete(action.payload);
       }
+      case EntityOp.SAVE_UPDATE_OPTIMISTIC:
       case EntityOp.SAVE_UPDATE: {
         return service.update(action.payload);
       }

--- a/lib/src/entity.reducer.spec.ts
+++ b/lib/src/entity.reducer.spec.ts
@@ -2,13 +2,12 @@ import { Action, ActionReducer, MetaReducer } from '@ngrx/store';
 import { EntityAdapter } from '@ngrx/entity';
 
 import { EntityAction, EntityActionFactory, EntityOp } from './entity.actions';
-import { EntityCache } from './interfaces';
+import { EntityCache, EntityCollection } from './interfaces';
+import { EntityCollectionCreator } from './entity-collection-creator';
 import { EntityDefinitionService } from './entity-definition.service';
 import { EntityMetadataMap } from './entity-metadata';
 import { Update } from './ngrx-entity-models';
 
-import { EntityCollection } from './entity-definition';
-import { EntityCollectionCreator } from './entity-collection-creator';
 import { EntityCollectionReducer, EntityCollectionReducerFactory } from './entity-collection.reducer';
 import { EntityCollectionReducers, EntityReducerFactory } from './entity.reducer';
 

--- a/lib/src/entity.selectors$.spec.ts
+++ b/lib/src/entity.selectors$.spec.ts
@@ -3,9 +3,8 @@ import { createFeatureSelector, createSelector, Selector, Store } from '@ngrx/st
 import { Observable } from 'rxjs/Observable';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
-import { EntityCache } from './interfaces';
-import { EntityCollection } from './entity-definition';
-import { EntityCollectionCreator } from './entity-collection-creator';
+import { EntityCache, EntityCollection } from './interfaces';
+import { EntityCollectionCreator, createEmptyEntityCollection } from './entity-collection-creator';
 import { EntityMetadata, EntityMetadataMap } from './entity-metadata';
 import { PropsFilterFnFactory } from './entity-filters';
 import { createEntitySelectors, EntitySelectors } from './entity.selectors';
@@ -29,15 +28,7 @@ describe('EntitySelectors$', () => {
   };
 
   /** As entityAdapter.initialState would create it */
-  const emptyHeroCollection: HeroCollection = {
-    ids: [],
-    entities: {},
-    filter: undefined,
-    loaded: false,
-    loading: false,
-    foo: 'foo',
-    bar: 3.14
-  }
+  const emptyHeroCollection = createHeroState({ foo: 'foo', bar: 3.14 })
 
   const villainMetadata: EntityMetadata<Villain> = {
     entityName: 'Villain',
@@ -50,15 +41,12 @@ describe('EntitySelectors$', () => {
 
     const entityCacheSelector = createFeatureSelector<EntityCache>('entityCache');
 
-    const initialState: HeroCollection = {
+    const initialState = createHeroState({
       ids: [1],
       entities: {1: {id: 1, name: 'A'}},
-      filter: '',
-      loaded: false,
-      loading: false,
       foo: 'foo foo',
       bar: 42
-    };
+    })
 
     beforeEach(() => {
       collectionCreator  = jasmine.createSpyObj('entityCollectionCreator', ['create']);
@@ -216,15 +204,14 @@ describe('EntitySelectors$', () => {
       // The default state feature exists to prevent selectors$ subscriptions
       // from bombing before the collection is initialized or
       // during time-travel debugging.
-      const defaultHeroState: HeroCollection = {
+      const defaultHeroState = createHeroState({
         ids: [1],
         entities: {1: {id: 1, name: 'A'}},
-        filter: '',
         loaded: true,
-        loading: false,
         foo: 'foo foo',
         bar: 42
-      };
+      });
+
       collectionCreator.create.and.returnValue(defaultHeroState);
       const selectors$ =
         factory.create<Hero, HeroSelectors$>('Hero', selectors); // <- override default state
@@ -244,6 +231,10 @@ describe('EntitySelectors$', () => {
 });
 
 /////// Test values and helpers /////////
+
+function createHeroState(state: Partial<HeroCollection>): HeroCollection {
+  return { ...createEmptyEntityCollection<Hero>(), ...state } as HeroCollection;
+}
 
 function nameFilter<T>(entities: T[], pattern: string) {
   return PropsFilterFnFactory<any>(['name'])(entities, pattern);

--- a/lib/src/entity.selectors$.ts
+++ b/lib/src/entity.selectors$.ts
@@ -5,11 +5,10 @@ import { createFeatureSelector, createSelector, Selector, Store } from '@ngrx/st
 import { Observable } from 'rxjs/Observable';
 
 import { EntityActions } from './entity.actions';
-import { EntityCollection } from './entity-definition';
 import { EntityCollectionCreator } from './entity-collection-creator';
 import { Dictionary } from './ngrx-entity-models';
 import { EntitySelectors } from './entity.selectors';
-import { EntityCache, ENTITY_CACHE_NAME_TOKEN } from './interfaces';
+import { EntityCache, EntityCollection, ENTITY_CACHE_NAME_TOKEN } from './interfaces';
 
 /**
  * The selector observable functions for entity collection members.
@@ -28,7 +27,7 @@ export interface EntitySelectors$<T> {
   entities$: Observable<T[]> | Store<T[]>;
 
   /** Observable of the map of entity keys to entities */
-  entityKeyMap$: Observable<Dictionary<T>> | Store<Dictionary<T>>;
+  entityMap$: Observable<Dictionary<T>> | Store<Dictionary<T>>;
 
   /** Observable of the filter pattern applied by the entity collection's filter function */
   filter$: Observable<string> | Store<string>;
@@ -44,6 +43,9 @@ export interface EntitySelectors$<T> {
 
   /** Observable true when a multi-entity query command is in progress. */
   loading$: Observable<boolean> | Store<boolean>;
+
+  /** Original entity values for entities with unsaved changes */
+  selectOriginalValues: Observable<Dictionary<T>> | Store<Dictionary<T>>;
 }
 
 @Injectable()

--- a/lib/src/entity.selectors.spec.ts
+++ b/lib/src/entity.selectors.spec.ts
@@ -1,6 +1,6 @@
 import { Selector } from '@ngrx/store';
 
-import { EntityCollection } from './entity-definition';
+import { EntityCollection } from './interfaces';
 import { EntityMetadata, EntityMetadataMap } from './entity-metadata';
 import { PropsFilterFnFactory } from './entity-filters';
 

--- a/lib/src/entity.selectors.ts
+++ b/lib/src/entity.selectors.ts
@@ -2,7 +2,7 @@ import { createSelector, Selector } from '@ngrx/store';
 
 import { Observable } from 'rxjs/Observable';
 
-import { EntityCollection } from './entity-definition';
+import { EntityCollection } from './interfaces';
 import { EntityFilterFn } from './entity-filters';
 import { EntityMetadata } from './entity-metadata';
 import { Dictionary } from './ngrx-entity-models';
@@ -18,7 +18,7 @@ export interface EntitySelectors<T> {
   selectEntities: Selector<EntityCollection<T>, T[]>;
 
   /** Map of entity keys to entities */
-  selectEntityKeyMap: Selector<EntityCollection<T>, Dictionary<T>>;
+  selectEntityMap: Selector<EntityCollection<T>, Dictionary<T>>;
 
   /** Filter pattern applied by the entity collection's filter function */
   selectFilter: Selector<EntityCollection<T>, string>;
@@ -31,6 +31,9 @@ export interface EntitySelectors<T> {
 
   /** True when a multi-entity query command is in progress. */
   selectLoading: Selector<EntityCollection<T>, boolean>;
+
+  /** Original entity values for entities with unsaved changes */
+  selectOriginalValues: Selector<EntityCollection<T>, Dictionary<T>>;
 }
 
 /**
@@ -45,11 +48,11 @@ export function createEntitySelectors<
 ): S {
   // Mostly copied from `@ngrx/entity/state_selectors.ts`
   const selectKeys = (c: EntityCollection<T>) => c.ids;
-  const selectEntityKeyMap = (c: EntityCollection<T>) => c.entities;
+  const selectEntityMap = (c: EntityCollection<T>) => c.entities;
 
   const selectEntities = createSelector(
     selectKeys,
-    selectEntityKeyMap,
+    selectEntityMap,
     (keys: any[], entities: Dictionary<T>): any => keys.map(key => entities[key] as T)
   );
 
@@ -67,6 +70,7 @@ export function createEntitySelectors<
 
   const selectLoaded = (c: EntityCollection<T>) => c.loaded;
   const selectLoading = (c: EntityCollection<T>) => c.loading;
+  const selectOriginalValues = (c: EntityCollection<T>) => c.originalValues;
 
   // Create selectors for each `additionalCollectionState` property.
   const extra = metadata.additionalCollectionState || {};
@@ -77,13 +81,14 @@ export function createEntitySelectors<
 
   return <S> <any> {
     selectKeys,
-    selectEntityKeyMap,
+    selectEntityMap,
     selectEntities,
     selectCount,
     selectFilter,
     selectFilteredEntities,
     selectLoaded,
     selectLoading,
+    selectOriginalValues,
     ...extraSelectors
   };
 }

--- a/lib/src/entity.service.spec.ts
+++ b/lib/src/entity.service.spec.ts
@@ -3,9 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { StoreModule, Store } from '@ngrx/store';
 
 import { EntityAction, EntityActionFactory, EntityOp } from './entity.actions';
-import { EntityCache } from './interfaces';
-import { EntityCollection } from './entity-definition';
-import { ENTITY_METADATA_TOKEN } from './interfaces';
+import { EntityCache, EntityCollection, ENTITY_METADATA_TOKEN } from './interfaces';
 import { EntityService, EntityServiceFactory } from './entity.service';
 
 import { _NgrxDataModuleWithoutEffects } from './ngrx-data.module'

--- a/lib/src/entity.service.ts
+++ b/lib/src/entity.service.ts
@@ -29,7 +29,8 @@ export class EntityServiceFactory {
   create<T, S extends EntityService<T> = EntityService<T>>(entityName: string): S {
     entityName = entityName.trim();
     const def = this.entityDefinitionService.getDefinition<T>(entityName);
-    const dispatcher = this.entityDispatcherFactory.create<T>(entityName, def.selectId);
+    const dispatcher =
+      this.entityDispatcherFactory.create<T>(entityName, def.selectId, def.entityDispatcherOptions);
     const selectors$ = this.entitySelectors$Factory.create(entityName, def.selectors);
 
     // Merge selectors$ properties into the dispatcher and return it

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -1,5 +1,11 @@
-export { DefaultDataService, DefaultDataServiceFactory } from './default-data.service';
+export {
+  DefaultDataService,
+  DefaultDataServiceConfig,
+  DefaultDataServiceFactory
+} from './default-data.service';
 export * from './entity.actions';
+export * from './entity-action-guard';
+export * from './entity-change-tracker';
 export { EntityCommands, EntityCacheCommands, EntityServerCommands } from './entity-commands';
 export * from './entity-collection.reducer';
 export * from './entity-collection-creator';

--- a/lib/src/interfaces.ts
+++ b/lib/src/interfaces.ts
@@ -1,10 +1,10 @@
 import { Injectable, InjectionToken } from '@angular/core';
 import { Action, Store, ActionReducer } from '@ngrx/store';
+import { EntityState } from '@ngrx/entity';
 
 import { Observable } from 'rxjs/Observable';
-import { EntityCollection } from './entity-definition';
 import { EntityMetadataMap } from './entity-metadata';
-import { IdSelector, Update } from './ngrx-entity-models';
+import { Dictionary, IdSelector, Update } from './ngrx-entity-models';
 
 export class DataServiceError {
   readonly message: string;
@@ -28,7 +28,7 @@ export const ENTITY_REDUCER_TOKEN = new InjectionToken<ActionReducer<EntityCache
 );
 export const PLURAL_NAMES_TOKEN = new InjectionToken<{ [name: string]: string }>('ngrx-data/Plural Names');
 
-/** A service that */
+/** A service that performs REST-like HTTP data operations */
 export interface EntityCollectionDataService<T> {
   readonly name: string;
   add(entity: T): Observable<T>;
@@ -44,12 +44,25 @@ export interface EntityCache {
   [name: string]: EntityCollection<any>;
 }
 
-@Injectable()
-export class EntityDataServiceConfig {
-  api? = 'api';
-  getDelay? = 0;
-  saveDelay? = 0;
-  timeout? = 0;
+export interface EntityCollection<T = any> extends EntityState<T> {
+  /** user's filter pattern */
+  filter: string;
+  /** true if collection was ever filled by QueryAll; forced false if cleared */
+  loaded: boolean;
+  /** true when multi-entity HTTP query operation is in flight */
+  loading: boolean;
+  /** Original entity values for entities with unsaved changes */
+  originalValues: Dictionary<T>;
+}
+
+/**
+ * Options controlling EntityDispatcher behavior
+ * such as whether `add()` is optimistic or pessimistic
+ */
+export interface EntityDispatcherOptions {
+  optimisticAdd: boolean;
+  optimisticDelete: boolean;
+  optimisticUpdate: boolean;
 }
 
 export type HttpMethods = 'DELETE' | 'GET' | 'POST' | 'PUT';

--- a/lib/src/ngrx-data.module.ts
+++ b/lib/src/ngrx-data.module.ts
@@ -9,14 +9,13 @@ import {
   EntityCache,
   ENTITY_CACHE_NAME,
   ENTITY_CACHE_NAME_TOKEN,
-  EntityDataServiceConfig,
+  EntityCollection,
   ENTITY_METADATA_TOKEN,
   ENTITY_COLLECTION_META_REDUCERS,
   ENTITY_REDUCER_TOKEN,
   PLURAL_NAMES_TOKEN
 } from './interfaces';
 
-import { EntityCollection } from './entity-definition';
 import { EntityCollectionCreator } from './entity-collection-creator';
 import { EntityCollectionReducerFactory } from './entity-collection.reducer';
 import { EntityDataService } from './entity-data.service';
@@ -35,7 +34,6 @@ import { Pluralizer, DefaultPluralizer } from './pluralizer';
 export const entityEffects: any[] = [EntityEffects];
 
 export interface NgrxDataModuleConfig {
-  entityDataServiceConfig?: EntityDataServiceConfig;
   entityMetadata?: EntityMetadataMap;
   entityCollectionMetaReducers?: MetaReducer<EntityCollection, EntityAction>[],
   pluralNames?: { [name: string]: string };
@@ -88,7 +86,6 @@ export class NgrxDataModule {
     return {
       ngModule: NgrxDataModule,
       providers: [
-        { provide: EntityDataServiceConfig, useValue: config.entityDataServiceConfig },
         { provide: ENTITY_METADATA_TOKEN, multi: true,
           useValue: config.entityMetadata ? config.entityMetadata : []},
         { provide: ENTITY_COLLECTION_META_REDUCERS,

--- a/lib/src/persistence-result-handler.service.ts
+++ b/lib/src/persistence-result-handler.service.ts
@@ -20,7 +20,7 @@ export abstract class PersistenceResultHandler {
 
   /** Handle error result of persistence operation for an action */
   abstract handleError(action: EntityAction):
-  (error: DataServiceError) => Observable<Action>
+  (error: DataServiceError | Error) => Observable<Action>
 }
 
 /**
@@ -43,13 +43,17 @@ export class DefaultPersistenceResultHandler implements PersistenceResultHandler
     (error: DataServiceError) => Observable<EntityAction<EntityActionDataServiceError>> {
 
     const errorOp = <EntityOp>(action.op + OP_ERROR);
-    return (error: DataServiceError) =>
-      of(
+    return (error: DataServiceError | Error) => {
+      if (error instanceof Error) {
+        error = new DataServiceError(error, null);
+      }
+      return of(
         this.entityActionFactory.create<EntityActionDataServiceError>(
           action as EntityAction,
           errorOp,
           { originalAction: action as EntityAction, error }
         )
       );
+    };
   }
 }

--- a/lib/src/utils.ts
+++ b/lib/src/utils.ts
@@ -1,6 +1,16 @@
 import { IdSelector, Update } from './ngrx-entity-models';
 
 /**
+ * Default function that returns the entity's primary key (pkey).
+ * Assumes that the entity has an `id` pkey property.
+ * Returns `undefined` if no entity or `id`.
+ * Every selectId fn must return `undefined` when it cannot produce a full pkey.
+ */
+export function defaultSelectId(entity: any) {
+  return entity == null ? undefined : entity.id;
+}
+
+/**
  * Flatten first arg if it is an array
  * Allows fn with ...rest signature to be called with an array instead of spread
  * Example:
@@ -26,7 +36,7 @@ export function flattenArgs<T>(args?: any[]): T[] {
  * `changes` is the entity (or partial entity of changes).
  */
 export function toUpdateFactory<T>(selectId?: IdSelector<T>) {
-  selectId = selectId || ((e: any) => e.id);
+  selectId = selectId || defaultSelectId as IdSelector<T>;
   /**
    * Convert an entity (or partial entity) into the `Update<T>`
    * whose `id` is the primary key and
@@ -34,6 +44,8 @@ export function toUpdateFactory<T>(selectId?: IdSelector<T>) {
    * @param selectId function that returns the entity's primary key (id)
    */
   return function toUpdate(entity: Partial<T>): Update<T> {
-    return entity && { id: selectId(entity) as any, changes: entity } ;
+    const id: any = selectId(entity);
+    if (id == null) { throw new Error('Primary key may not be null/undefined.'); }
+    return entity && { id, changes: entity } ;
   }
 }

--- a/src/client/app/core/core.module.ts
+++ b/src/client/app/core/core.module.ts
@@ -2,6 +2,7 @@ import { NgModule, Optional, SkipSelf } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 
+import { IdGeneratorService } from './id-generator.service';
 import { ToggleDataSourceComponent } from './toggle-data-source.component';
 import { ToolbarComponent } from './toolbar/toolbar.component';
 import { SharedModule } from '../shared/shared.module';
@@ -17,7 +18,7 @@ import { throwIfAlreadyLoaded } from './module-import-check';
   ],
   declarations: [ToggleDataSourceComponent, ToolbarComponent],
   exports: [ToggleDataSourceComponent, ToolbarComponent],
-  providers: [NgrxDataToastService, ToastService]
+  providers: [IdGeneratorService, NgrxDataToastService, ToastService]
 })
 export class CoreModule {
   constructor(

--- a/src/client/app/core/id-generator.service.ts
+++ b/src/client/app/core/id-generator.service.ts
@@ -1,0 +1,18 @@
+// Need a client-side id-generator for Villain,
+// which is configured for optimistic ADD in EntityMetadata.
+import { Injectable } from '@angular/core';
+
+/*
+ * DEMO ONLY client-side id (key) generator
+ * The ids it generates are not guaranteed to be unique across all users.
+ * DO NOT USE THIS GENERATOR.
+ */
+@Injectable()
+export class IdGeneratorService {
+  private counter = 1;
+
+  /** Generate nextId for new entities with number keys */
+  nextId(): number {
+    return Date.now() + this.counter++;
+  }
+}

--- a/src/client/app/core/index.ts
+++ b/src/client/app/core/index.ts
@@ -1,3 +1,4 @@
 export * from './model';
 export * from './in-memory-data.service';
 export * from './toast.service';
+export { IdGeneratorService } from './id-generator.service';

--- a/src/client/app/core/model/hero.ts
+++ b/src/client/app/core/model/hero.ts
@@ -1,11 +1,4 @@
 export class Hero {
-  static generateMockHero(): Hero {
-    return {
-      id: 0,
-      name: '',
-      saying: ''
-    };
-  }
   constructor(
     public readonly id: number,
     public readonly name: string,

--- a/src/client/app/core/model/villain.ts
+++ b/src/client/app/core/model/villain.ts
@@ -1,11 +1,4 @@
 export class Villain {
-  static generateMockVillain(): Villain {
-    return {
-      id: 0,
-      name: '',
-      saying: ''
-    };
-  }
   constructor(
     public readonly id: number,
     public readonly name: string,

--- a/src/client/app/store/entity-metadata.ts
+++ b/src/client/app/store/entity-metadata.ts
@@ -1,4 +1,4 @@
-import { EntityMetadataMap, PropsFilterFnFactory } from 'ngrx-data';
+import { defaultSelectId, EntityMetadataMap, PropsFilterFnFactory } from 'ngrx-data';
 
 import { Hero, Villain } from '../core/model';
 
@@ -14,7 +14,7 @@ export function sortByName(a: { name: string }, b: { name: string }): number {
  * It isn't necessary because `id` is the primary key property by default.
  */
 export function selectId<T extends { id: any }>(entity: T) {
-  return entity.id;
+  return entity == null ? undefined : entity.id;
 }
 
 /** Filter for entities whose name matches the case-insensitive pattern */
@@ -29,15 +29,19 @@ export function nameAndSayingFilter<T>(entities: T[], pattern: string) {
 ////////////
 
 export const entityMetadata: EntityMetadataMap = {
+
   Hero: {
     entityName: 'Hero', // required for minification
-    selectId, // not necessary but shows you can supply a function
+    selectId: selectId, // not necessary but shows you can supply a function
     sortComparer: sortByName,
     filterFn: nameFilter
   },
+
   Villain: {
     entityName: 'Villain', // required for minification
-    filterFn: nameAndSayingFilter
+    filterFn: nameAndSayingFilter,
+    // Optional: set certain default dispatcher behaviors
+    entityDispatcherOptions: { optimisticAdd: true, optimisticUpdate: true }
   }
 };
 

--- a/src/client/app/store/entity-store.module.ts
+++ b/src/client/app/store/entity-store.module.ts
@@ -1,23 +1,27 @@
 import { NgModule } from '@angular/core';
 
-import { EntityDataServiceConfig, NgrxDataModule } from 'ngrx-data';
+import { DefaultDataServiceConfig, NgrxDataModule } from 'ngrx-data';
 
 import { pluralNames, entityMetadata } from './entity-metadata';
 
-const entityDataServiceConfig: EntityDataServiceConfig = {
-  api: 'api',
+const defaultDataServiceConfig: DefaultDataServiceConfig = {
+  root: 'api',    // root path to web api
+  timeout: 3000, // request timeout
+
+  // Simulate latency for demo
   getDelay: 500,
-  saveDelay: 300,
-  timeout: 3000
+  saveDelay: 800,
 };
 
 @NgModule({
   imports: [
     NgrxDataModule.forRoot({
-      entityDataServiceConfig,
       entityMetadata: entityMetadata,
       pluralNames: pluralNames
     })
+  ],
+  providers: [
+    { provide: DefaultDataServiceConfig, useValue: defaultDataServiceConfig }
   ]
 })
 export class EntityStoreModule {}

--- a/src/client/app/villains/villain-list/villain-list.component.html
+++ b/src/client/app/villains/villain-list/villain-list.component.html
@@ -10,7 +10,7 @@
           <mat-icon>delete</mat-icon>
         </button>
         <div class="selectable-item" [class.selected]="villain === selectedVillain">
-          <div class="badge">{{villain.id}}</div>
+          <div class="badge truncate" [title]="villain.id">{{villain.id}}</div>
           <div class="item-text" (click)="onSelect(villain)">
             <div class="name">{{villain.name}}</div>
             <div class="saying">{{villain.saying}}</div>

--- a/src/client/app/villains/villain-list/villain-list.component.scss
+++ b/src/client/app/villains/villain-list/villain-list.component.scss
@@ -7,3 +7,10 @@
 .mat-card {
   @include mat-card-layout;
 }
+
+.truncate {
+  width: 1.5em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/src/client/app/villains/villains/villains.component.ts
+++ b/src/client/app/villains/villains/villains.component.ts
@@ -8,7 +8,7 @@ import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
 import { takeUntil } from 'rxjs/operators';
 
-import { Villain } from '../../core';
+import { Villain, IdGeneratorService } from '../../core';
 
 @Component({
   selector: 'app-villain-search',
@@ -26,7 +26,11 @@ export class VillainsComponent implements OnDestroy, OnInit {
   filteredVillains$: Observable<Villain[]>;
   loading$: Observable<boolean>;
 
-  constructor(appSelectors: AppSelectors, entityServiceFactory: EntityServiceFactory) {
+  constructor(
+    appSelectors: AppSelectors,
+    entityServiceFactory: EntityServiceFactory,
+    private idGenerator: IdGeneratorService) {
+
     this.dataSource$ = appSelectors.dataSource$();
     this.villainService = entityServiceFactory.create<Villain>('Villain');
     this.filteredVillains$ = this.villainService.filteredEntities$;
@@ -73,7 +77,10 @@ export class VillainsComponent implements OnDestroy, OnInit {
   }
 
   add(villain: Villain) {
-    this.villainService.add(villain);
+    // MUST generate id for villains because
+    // it is configured for optimistic ADD in EntityMetadata.
+    const id = this.idGenerator.nextId();
+    this.villainService.add({ ...villain, id });
   }
 
   unselect() {


### PR DESCRIPTION
- release alpha.7
- add `EntityChangeTracker` to hold original values that can be reverted on error
- add optimistic persistence EntityOps and actions
- alter dispatcher to support them
- move EntityCollection<T> to interfaces.ts
- add/fix related tests

**See ChangeLog for alpha.7**