### PR TITLE
fix: add missing implementation for EntitySelectors$.actions$

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ Please look there.
 
 **_This_** Changelog covers changes to the repository and the demo applications.
 
+<a name="0.2.7"></a>
+# 0.2.7 (2018-03-09)
+
+Added `VillainEditor` to demonstrate routing to a detail component 
+(e.g., `/villains/21`) which tries to get the entity from cache but, if it can't find it,
+attempts a `EntityService.getByKey()`.
+
+This `VillainEditor` also shows 
+* creating a `villain$` that combines the parameter id observable with the `entityMap$` selector
+so can find the villain for the routed `id`.
+* the `villain$` has the side-effect of dispatching `QUERY_BY_KEY` if no cached villain for that id.
+* creating `error$` to watch for `QUERY_BY_KEY_ERROR` when the request fails (try `/villains/1`)
+* creating a `loading$` observable that combines the `error$` with `$villain`
+
+Depends on alpha.14
+
 <a name="0.2.6"></a>
 # 0.2.6 (2018-03-05)
 

--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Angular ngrx-data library ChangeLog
 
+<a name="1.0.0-alpha.14"></a>
+# release 1.0.0-alpha.14 (2018-03-09)
+
+* Bug fix: `EntitySelectors$.actions$` now implemented (it wasn't).
+* Bug fix: DefaultDataService adds delay on server errors too (see `makeResponseDelay`).
+* Corrected text of the type constants for the QUERY_BY_KEY actions.
+
 <a name="1.0.0-alpha.13"></a>
 # release 1.0.0-alpha.13 (2018-03-07)
 

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngrx-data",
-  "version": "1.0.0-alpha.13",
+  "version": "1.0.0-alpha.14",
   "repository": "https://github.com/johnpapa/angular-ngrx-data.git",
   "license": "MIT",
   "peerDependencies": {

--- a/lib/src/actions/entity-actions.ts
+++ b/lib/src/actions/entity-actions.ts
@@ -23,7 +23,8 @@ export class EntityActions<V extends EntityAction = EntityAction> extends Observ
     super();
 
     if (source) {
-      this.source = source;
+      // ONLY look at EntityActions
+      this.source = source.pipe(filter((action: any) => action.op && action.entityName));
     }
   }
 
@@ -90,7 +91,7 @@ export class EntityActions<V extends EntityAction = EntityAction> extends Observ
   ofOp(...allowedOps: any[]) {
     // string is the runtime type of an EntityOp enum
     const ops: string[] = flattenArgs(allowedOps);
-    return this.where(ea => ea.op && ops.some(op => op === ea.op));
+    return this.where(ea => ops.some(op => op === ea.op));
   }
 
   /**
@@ -107,7 +108,7 @@ export class EntityActions<V extends EntityAction = EntityAction> extends Observ
   ofType(...allowedTypes: string[]): EntityActions;
   ofType(...allowedTypes: any[]): EntityActions {
     const types: string[] = flattenArgs(allowedTypes);
-    return this.where(ea => !!ea.entityName && types.some(type => type === ea.type));
+    return this.where(ea => types.some(type => type === ea.type));
   }
 
   /**

--- a/lib/src/actions/entity-op.ts
+++ b/lib/src/actions/entity-op.ts
@@ -18,9 +18,9 @@ export enum EntityOp {
   QUERY_MANY_SUCCESS = 'ngrx-data/query-many/success',
   QUERY_MANY_ERROR = 'ngrx-data/query-many/error',
 
-  QUERY_BY_KEY = 'ngrx-data/query-by-id',
-  QUERY_BY_KEY_SUCCESS = 'ngrx-data/query-by-id/success',
-  QUERY_BY_KEY_ERROR = 'ngrx-data/query-by-id/error',
+  QUERY_BY_KEY = 'ngrx-data/query-by-key',
+  QUERY_BY_KEY_SUCCESS = 'ngrx-data/query-by-key/success',
+  QUERY_BY_KEY_ERROR = 'ngrx-data/query-by-key/error',
 
   SAVE_ADD_ONE = 'ngrx-data/save/add-one',
   SAVE_ADD_ONE_ERROR = 'ngrx-data/save/add-one/error',

--- a/lib/src/dataservices/default-data.service.ts
+++ b/lib/src/dataservices/default-data.service.ts
@@ -5,11 +5,12 @@ import { Observable } from 'rxjs/Observable';
 import { ErrorObservable } from 'rxjs/observable/ErrorObservable';
 import { of } from 'rxjs/observable/of';
 import { pipe } from 'rxjs/util/pipe';
-import { catchError, delay, map, tap, timeout } from 'rxjs/operators';
+import { catchError, map, tap, timeout } from 'rxjs/operators';
 
 import { DataServiceError } from './data-service-error';
 import { HttpMethods, QueryParams, RequestData } from './index';
 import { HttpUrlGenerator } from './http-url-generator';
+import { makeResponseDelay } from './make-response-delay';
 
 import { EntityCollectionDataService } from './entity-data.service';
 import { Update } from '../utils';
@@ -69,8 +70,8 @@ export class DefaultDataService<T> implements EntityCollectionDataService<T> {
     this.delete404OK = delete404OK;
     this.entityUrl = httpUrlGenerator.entityResource(entityName, root);
     this.entitiesUrl = httpUrlGenerator.collectionResource(entityName, root);
-    this.getDelay = getDelay ? delay(getDelay) : noDelay;
-    this.saveDelay = saveDelay ? delay(saveDelay) : noDelay;
+    this.getDelay = getDelay ? makeResponseDelay(getDelay) : noDelay;
+    this.saveDelay = saveDelay ? makeResponseDelay(saveDelay) : noDelay;
     this.timeout = to ? timeout(to) : noDelay;
   }
 

--- a/lib/src/dataservices/index.ts
+++ b/lib/src/dataservices/index.ts
@@ -2,6 +2,7 @@ export * from './data-service-error';
 export * from './default-data.service';
 export * from './entity-data.service';
 export * from './http-url-generator';
+export * from './make-response-delay';
 export * from './persistence-result-handler.service';
 
 export type HttpMethods = 'DELETE' | 'GET' | 'POST' | 'PUT';

--- a/lib/src/dataservices/make-response-delay.ts
+++ b/lib/src/dataservices/make-response-delay.ts
@@ -1,0 +1,31 @@
+import { Observable } from 'rxjs/Observable';
+
+/** Return an operator function that adds specified delay (in ms) to both next and error channels */
+export function makeResponseDelay(delayMs: number) {
+  return <T> (source: Observable<T>): Observable<T> =>
+    new Observable<T>(observer => {
+      let completePending = false;
+      let nextPending = false;
+      const subscription = source.subscribe(
+        value => {
+            nextPending = true;
+            setTimeout(() => {
+            observer.next(value);
+            if (completePending) {
+              observer.complete();
+            }
+          }, delayMs);
+        },
+        error => setTimeout(() => observer.error(error), delayMs),
+        () => {
+          completePending = true;
+          if (!nextPending) {
+            observer.complete();
+          }
+        }
+      );
+      return () => {
+        return subscription.unsubscribe();
+      };
+    });
+}

--- a/lib/src/entity-service/entity.service.spec.ts
+++ b/lib/src/entity-service/entity.service.spec.ts
@@ -1,8 +1,10 @@
 /** TODO: much more testing */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { StoreModule, Store } from '@ngrx/store';
+import { Action, StoreModule, Store } from '@ngrx/store';
 
-import { EntityAction, EntityActionFactory, EntityOp } from '../actions';
+import { Subject } from 'rxjs/Subject';
+
+import { EntityAction, EntityActions, EntityActionFactory, EntityOp } from '../actions';
 import { EntityCache, EntityCollection } from '../reducers';
 import { ENTITY_METADATA_TOKEN } from '../entity-metadata';
 import { EntityService, EntityServiceFactory } from './entity.service';
@@ -78,6 +80,8 @@ const heroMetadata = {
 }
 
 function entityServiceFactorySetup() {
+  const actions$ = new Subject<Action>();
+  const entityActions = new EntityActions(<any> actions$);
 
   TestBed.configureTestingModule({
     imports: [
@@ -85,6 +89,7 @@ function entityServiceFactorySetup() {
       _NgrxDataModuleWithoutEffects
     ],
     providers: [
+      { provide: EntityActions, useValue: entityActions },
       { provide: ENTITY_METADATA_TOKEN, multi: true, useValue: {
         Hero: heroMetadata
       }},
@@ -97,7 +102,7 @@ function entityServiceFactorySetup() {
   const entityActionFactory: EntityActionFactory = TestBed.get(EntityActionFactory);
   const entityServiceFactory: EntityServiceFactory = TestBed.get(EntityServiceFactory);
 
-  return { entityActionFactory, entityServiceFactory, testStore };
+  return { actions$, entityActions, entityActionFactory, entityServiceFactory, testStore };
 }
 
 function heroDispatcherSetup() {

--- a/lib/src/entity-service/entity.service.ts
+++ b/lib/src/entity-service/entity.service.ts
@@ -262,7 +262,6 @@ export class EntityServiceBase<T, S$ extends EntitySelectors$<T> = EntitySelecto
 
   // region Selectors$
   /** Observable of actions related to this entity type. */
-
   actions$: EntityActions;
 
   /** Observable of the collection as a whole */

--- a/lib/src/selectors/entity-selectors$.ts
+++ b/lib/src/selectors/entity-selectors$.ts
@@ -58,7 +58,8 @@ export class EntitySelectors$Factory {
   constructor(
     @Inject(ENTITY_CACHE_NAME_TOKEN) cacheName: string,
     private entityCollectionCreator: EntityCollectionCreator,
-    private store: Store<any>
+    private store: Store<any>,
+    private entityActions$: EntityActions
   ) {
       // This service applies to the cache in ngrx/store named `cacheName`
       this.cacheSelector = createFeatureSelector<EntityCache>(cacheName);
@@ -80,7 +81,7 @@ export class EntitySelectors$Factory {
     const cc = createCachedCollectionSelector<T>(entityName, this.cacheSelector, this.entityCollectionCreator);
     const collection$ = this.store.select(cc);
 
-    const selectors$: Partial<EntitySelectors$<T>> = {};
+    const selectors$: S$ = <any> {};
 
     Object.keys(selectors).forEach(
       name => {
@@ -90,9 +91,10 @@ export class EntitySelectors$Factory {
         (<any>selectors$)[name$] = collection$.select((<any>selectors)[name]
       )}
     );
-    (<any>selectors$)['collection$'] = collection$;
+    selectors$.actions$ = this.entityActions$.ofEntityType(entityName);
+    selectors$.collection$ = collection$;
 
-    return selectors$ as S$;
+    return selectors$;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-ngrx-data",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/client/app/app-routing.module.ts
+++ b/src/client/app/app-routing.module.ts
@@ -10,7 +10,9 @@ const routes: Routes = [
   {
     path: 'villains',
     loadChildren: 'app/villains/villains.module#VillainsModule'
-  }
+  },
+  { path: '**', redirectTo: 'heroes' } // bad routes redirect to heroes
+
 ];
 
 @NgModule({

--- a/src/client/app/store/ngrx-data-toast.service.ts
+++ b/src/client/app/store/ngrx-data-toast.service.ts
@@ -1,11 +1,10 @@
 import { Injectable, OnDestroy } from '@angular/core';
-import { Actions } from '@ngrx/effects';
 
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
 import { filter, takeUntil, tap } from 'rxjs/operators';
 
-import { EntityAction, OP_ERROR, OP_SUCCESS } from 'ngrx-data';
+import { EntityAction, EntityActions, OP_ERROR, OP_SUCCESS } from 'ngrx-data';
 
 import { ToastService } from '../core/toast.service';
 
@@ -14,17 +13,14 @@ import { ToastService } from '../core/toast.service';
 export class NgrxDataToastService implements OnDestroy {
   private onDestroy = new Subject();
 
-  constructor(actions$: Actions, toast: ToastService) {
-    actions$
-      .pipe(
-        filter(
-          (ea: EntityAction) =>
-            ea.op &&
-            (ea.op.includes(OP_SUCCESS) || ea.op.includes(OP_ERROR))
-        ),
-        takeUntil(this.onDestroy)
-      )
-      .subscribe(action => toast.openSnackBar(`${action.entityName} action`, action.op));
+  constructor(actions$: EntityActions, toast: ToastService) {
+    actions$.pipe(
+      filter(ea => ea.op.includes(OP_SUCCESS) || ea.op.includes(OP_ERROR)),
+      takeUntil(this.onDestroy)
+    )
+    .subscribe(action =>
+      toast.openSnackBar(`${action.entityName} action`, action.op)
+    );
   }
 
   ngOnDestroy() {

--- a/src/client/app/villains/villain-editor/villain-editor.component.html
+++ b/src/client/app/villains/villain-editor/villain-editor.component.html
@@ -1,0 +1,11 @@
+<div class="content-container">
+  <div *ngIf="error$ | async as emsg" class="error">{{emsg}}</div>
+  <div class="detail-container">
+      <mat-spinner *ngIf="loading$ | async; else detail" mode="indeterminate" color="accent"></mat-spinner>
+    <ng-template #detail>
+      <app-villain-detail *ngIf="villain$ | async as villain" [villain]="villain" (unselect)="unselect()"
+        (update)="update($event)">
+      </app-villain-detail>
+    </ng-template>
+  </div>
+</div>

--- a/src/client/app/villains/villain-editor/villain-editor.component.scss
+++ b/src/client/app/villains/villain-editor/villain-editor.component.scss
@@ -1,0 +1,14 @@
+@import '../../../styles/mixin';
+
+.control-panel {
+  @include control-panel-layout;
+}
+.content-container {
+  @include content-container-layout;
+}
+
+.error {
+  color: red;
+  font-size: 200%;
+  margin-left: 20px;
+}

--- a/src/client/app/villains/villain-editor/villain-editor.component.ts
+++ b/src/client/app/villains/villain-editor/villain-editor.component.ts
@@ -1,0 +1,78 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import { EntityOp } from 'ngrx-data';
+
+import { Observable } from 'rxjs/Observable';
+import { Subject } from 'rxjs/Subject';
+import { combineLatest, map, shareReplay, startWith, takeUntil } from 'rxjs/operators';
+
+import { Villain } from '../../core';
+import { VillainsService } from '../villains.service';
+
+@Component({
+  selector: 'app-villain-editor',
+  templateUrl: './villain-editor.component.html',
+  styleUrls: ['./villain-editor.component.scss']
+})
+export class VillainEditorComponent implements OnInit, OnDestroy {
+
+  destroy$ = new Subject();
+  error$: Observable<string>;
+  loading$: Observable<boolean>;
+  villain$: Observable<Villain>;
+
+  constructor(
+    private villainsService: VillainsService,
+    private route: ActivatedRoute,
+    private router: Router
+  ) { }
+
+  ngOnInit() {
+
+    this.villain$ = this.route.params.pipe(
+      map(params => params['id']),
+      combineLatest(
+        this.villainsService.entityMap$,
+        (id, entityMap) => {
+          // look for it by key in the cached collection
+          const villain = entityMap[id] ;
+          if (!villain) {
+            // not in cache; dispatch request to get it
+            this.villainsService.getByKey(id);
+          }
+          return villain;
+        }
+      ),
+      takeUntil(this.destroy$), // must be just before shareReplay
+      shareReplay(1)
+    );
+
+    this.error$ = this.villainsService.actions$.ofOp(EntityOp.QUERY_BY_KEY_ERROR)
+    .pipe(
+      map(errorAction => errorAction.payload.error.message),
+      startWith(''), // prime it for loading$
+      takeUntil(this.destroy$)
+    );
+
+    this.loading$ = this.error$.pipe(
+      combineLatest(
+        this.villain$,
+        (errorMsg, villain) => !villain && !errorMsg
+      )
+    );
+  }
+
+  ngOnDestroy() {
+    this.destroy$.next();
+  }
+
+  update(villain: any) {
+    this.villainsService.update(villain);
+  }
+
+  unselect() {
+    this.router.navigate(['/villains']);
+  }
+
+}

--- a/src/client/app/villains/villains-routing.module.ts
+++ b/src/client/app/villains/villains-routing.module.ts
@@ -2,8 +2,12 @@ import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 
 import { VillainsComponent } from './villains/villains.component';
+import { VillainEditorComponent } from './villain-editor/villain-editor.component';
 
-const routes: Routes = [{ path: '', pathMatch: 'full', component: VillainsComponent }];
+const routes: Routes = [
+  { path: '', pathMatch: 'full', component: VillainsComponent },
+  { path: ':id', component: VillainEditorComponent }
+];
 
 @NgModule({
   imports: [RouterModule.forChild(routes)],

--- a/src/client/app/villains/villains.module.ts
+++ b/src/client/app/villains/villains.module.ts
@@ -7,6 +7,7 @@ import { SharedModule } from '../shared/shared.module';
 import { VillainsRoutingModule } from './villains-routing.module';
 import { VillainListComponent } from './villain-list/villain-list.component';
 import { VillainDetailComponent } from './villain-detail/villain-detail.component';
+import { VillainEditorComponent } from './villain-editor/villain-editor.component';
 import { VillainsComponent } from './villains/villains.component';
 import { VillainsService } from './villains.service';
 
@@ -14,7 +15,7 @@ import { VillainsService } from './villains.service';
 @NgModule({
   imports: [CommonModule, ReactiveFormsModule, VillainsRoutingModule, SharedModule],
   exports: [VillainListComponent, VillainDetailComponent],
-  declarations: [VillainListComponent, VillainDetailComponent, VillainsComponent],
+  declarations: [VillainListComponent, VillainDetailComponent, VillainEditorComponent, VillainsComponent],
   providers: [ VillainsService ]
 })
 export class VillainsModule {}


### PR DESCRIPTION
Library release alpha.14
See library CHANGELOG.md
Also demonstrate an approach to get-by-id-from-cache-then-server in VillainEditor