### PR TITLE
refactor: simplify EntitySelectorFactory and friends -  Beta.11

### DIFF
--- a/docs/publishing-checklist.md
+++ b/docs/publishing-checklist.md
@@ -13,7 +13,7 @@ Here is our checklist.
 
 1.  Bump the npm package version number in `lib/package.json`.
 
-1.  Run `npm run build-publish`. This command builds the library one more time before publishing to npm.
+1.  Run `npm run build-publish`. This command builds the library one more time and then publishes to npm.
 
 > The publish step will fail if you aren't authorized to publish.
 >

--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Angular ngrx-data library ChangeLog
 
+<a name="1.0.0-beta.11"></a>
+
+# 1.0.0-beta.11 (2018-04-29)
+
+Add EntitySelectorFactory method overloads to simplify related-entity selector creation.
+Clarify return types on EntitySelector interfaces
+Add `EntityCacheSelector` which can be injected
+Minor _break_ in signature of `EntitySelectorFactory$` constructor to use `EntityCacheSelector`
+instead of `EntitySelectorFactory`
+
 <a name="1.0.0-beta.10"></a>
 
 # 1.0.0-beta.10 (2018-04-22)

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngrx-data",
-  "version": "1.0.0-beta.10",
+  "version": "1.0.0-beta.11",
   "repository": "https://github.com/johnpapa/angular-ngrx-data.git",
   "license": "MIT",
   "peerDependencies": {

--- a/lib/src/ngrx-data.module.ts
+++ b/lib/src/ngrx-data.module.ts
@@ -30,6 +30,7 @@ import { EntityServiceFactory } from './entity-service/entity-service-interfaces
 import { DefaultEntityServiceFactory } from './entity-service/default-entity-service-factory';
 
 import { EntityCache } from './reducers/entity-cache';
+import { entityCacheSelectorProvider } from './selectors/entity-cache-selector';
 import { EntityCollection } from './reducers/entity-collection';
 import { EntityCollectionCreator } from './reducers/entity-collection-creator';
 import {
@@ -73,6 +74,7 @@ export interface NgrxDataModuleConfig {
   imports: [StoreModule.forFeature(ENTITY_CACHE_NAME, ENTITY_REDUCER_TOKEN)],
   providers: [
     EntityActionFactory,
+    entityCacheSelectorProvider,
     EntityCollectionCreator,
     EntityCollectionReducerFactory,
     EntityDefinitionService,
@@ -84,6 +86,9 @@ export interface NgrxDataModuleConfig {
       provide: EntityCollectionReducerMethodsFactory,
       useClass: DefaultEntityCollectionReducerMethodsFactory
     },
+    // Developer cannot replace cache name this way. Too late.
+    // TODO: find a way to delay `StoreModule.forFeature()` until cache name is known.
+    // That solution will also enable ability to initialize the cache.
     { provide: ENTITY_CACHE_NAME_TOKEN, useValue: ENTITY_CACHE_NAME },
     {
       provide: ENTITY_REDUCER_TOKEN,

--- a/lib/src/reducers/entity-collection-creator.ts
+++ b/lib/src/reducers/entity-collection-creator.ts
@@ -1,27 +1,36 @@
-import { Injectable } from '@angular/core';
+import { Injectable, Optional } from '@angular/core';
 
 import { EntityCollection } from './entity-collection';
 import { EntityDefinitionService } from '../entity-metadata/entity-definition.service';
 
 @Injectable()
 export class EntityCollectionCreator {
-
-  constructor(private entityDefinitionService: EntityDefinitionService) { }
+  constructor(
+    @Optional() private entityDefinitionService?: EntityDefinitionService
+  ) {}
 
   /**
    * Create the default collection for an entity type.
    * @param entityName {string} entity type name
    */
-  create<T = any, S extends EntityCollection<T> = EntityCollection<T>>(entityName: string): S {
-    const def = this.entityDefinitionService.getDefinition<T>(entityName, /*shouldThrow*/ false);
-    return <S> (def ?
-      def.initialState || createEmptyEntityCollection<T>() :
-      createEmptyEntityCollection<T>());
+  create<T = any, S extends EntityCollection<T> = EntityCollection<T>>(
+    entityName: string
+  ): S {
+    const def =
+      this.entityDefinitionService &&
+      this.entityDefinitionService.getDefinition<T>(
+        entityName,
+        /*shouldThrow*/ false
+      );
+
+    const initialState = def && def.initialState;
+
+    return <S>(initialState || createEmptyEntityCollection<T>());
   }
 }
 
 export function createEmptyEntityCollection<T>(): EntityCollection<T> {
-  return  {
+  return {
     ids: [],
     entities: {},
     filter: undefined,

--- a/lib/src/selectors/entity-cache-selector.ts
+++ b/lib/src/selectors/entity-cache-selector.ts
@@ -1,0 +1,36 @@
+import {
+  Inject,
+  Injectable,
+  InjectionToken,
+  Optional,
+  FactoryProvider
+} from '@angular/core';
+import {
+  createFeatureSelector,
+  createSelector,
+  MemoizedSelector
+} from '@ngrx/store';
+import { EntityCache } from '../reducers/entity-cache';
+import {
+  ENTITY_CACHE_NAME,
+  ENTITY_CACHE_NAME_TOKEN
+} from '../reducers/constants';
+
+export const ENTITY_CACHE_SELECTOR_TOKEN = new InjectionToken<
+  MemoizedSelector<Object, EntityCache>
+>('ngrx-data/EntityCache selector');
+
+export const entityCacheSelectorProvider: FactoryProvider = {
+  provide: ENTITY_CACHE_SELECTOR_TOKEN,
+  useFactory: createEntityCacheSelector,
+  deps: [[new Optional(), ENTITY_CACHE_NAME_TOKEN]]
+};
+
+export type EntityCacheSelector = MemoizedSelector<Object, EntityCache>;
+
+export function createEntityCacheSelector(
+  entityCacheName?: string
+): MemoizedSelector<Object, EntityCache> {
+  entityCacheName = entityCacheName || ENTITY_CACHE_NAME;
+  return createFeatureSelector<EntityCache>(entityCacheName);
+}

--- a/lib/src/selectors/entity-selectors$.spec.ts
+++ b/lib/src/selectors/entity-selectors$.spec.ts
@@ -1,4 +1,4 @@
-import { Action, createSelector, Selector, Store } from '@ngrx/store';
+import { Action, createSelector, MemoizedSelector, Store } from '@ngrx/store';
 
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
@@ -17,6 +17,11 @@ import {
 } from '../reducers';
 import { EntityMetadata, EntityMetadataMap } from '../entity-metadata';
 import { PropsFilterFnFactory } from '../entity-metadata';
+import {
+  ENTITY_CACHE_SELECTOR_TOKEN,
+  EntityCacheSelector,
+  createEntityCacheSelector
+} from './entity-cache-selector';
 import { EntitySelectors, EntitySelectorsFactory } from './entity-selectors';
 import { EntitySelectors$, EntitySelectors$Factory } from './entity-selectors$';
 
@@ -87,7 +92,6 @@ describe('EntitySelectors$', () => {
       ]);
       collectionCreator.create.and.returnValue(emptyHeroCollection);
       const entitySelectorsFactory = new EntitySelectorsFactory(
-        ENTITY_CACHE_NAME,
         collectionCreator
       );
       heroCollectionSelectors = entitySelectorsFactory.create<
@@ -97,9 +101,9 @@ describe('EntitySelectors$', () => {
 
       // EntitySelectorFactory
       factory = new EntitySelectors$Factory(
-        entitySelectorsFactory,
         store,
-        entityActions
+        entityActions,
+        createEntityCacheSelector(ENTITY_CACHE_NAME)
       );
 
       // listen for changes to the hero collection
@@ -300,8 +304,8 @@ interface HeroCollection extends EntityCollection<Hero> {
 
 /** HeroSelectors identifies the extra selectors for the extra collection properties */
 interface HeroSelectors extends EntitySelectors<Hero> {
-  selectFoo: Selector<Object, string>;
-  selectBar: Selector<Object, number>;
+  selectFoo: MemoizedSelector<Object, string>;
+  selectBar: MemoizedSelector<Object, number>;
 }
 
 /** HeroSelectors identifies the extra selectors for the extra collection properties */

--- a/lib/src/selectors/entity-selectors$.ts
+++ b/lib/src/selectors/entity-selectors$.ts
@@ -13,9 +13,12 @@ import { Dictionary } from '../utils/ngrx-entity-models';
 import { EntityAction } from '../actions/entity-action';
 import { EntityActions } from '../actions/entity-actions';
 import { OP_ERROR } from '../actions/entity-op';
+import {
+  ENTITY_CACHE_SELECTOR_TOKEN,
+  EntityCacheSelector
+} from './entity-cache-selector';
 import { EntitySelectors } from './entity-selectors';
 import { EntityCache } from '../reducers/entity-cache';
-import { ENTITY_CACHE_NAME_TOKEN } from '../reducers/constants';
 import { EntityCollection } from '../reducers/entity-collection';
 import { EntityCollectionCreator } from '../reducers/entity-collection-creator';
 import { EntitySelectorsFactory } from './entity-selectors';
@@ -69,19 +72,17 @@ export interface EntitySelectors$<T> {
 
 @Injectable()
 export class EntitySelectors$Factory {
-  selectCache: Selector<Object, EntityCache>;
-
   /** Observable of the EntityCache */
   entityCache$: Store<EntityCache>;
 
   constructor(
-    private entitySelectorsFactory: EntitySelectorsFactory,
     private store: Store<any>,
-    private entityActions$: EntityActions
+    private entityActions$: EntityActions,
+    @Inject(ENTITY_CACHE_SELECTOR_TOKEN)
+    private selectEntityCache: EntityCacheSelector
   ) {
     // This service applies to the cache in ngrx/store named `cacheName`
-    this.selectCache = entitySelectorsFactory.selectEntityCache;
-    this.entityCache$ = this.store.select(this.selectCache);
+    this.entityCache$ = this.store.select(this.selectEntityCache);
   }
 
   /**

--- a/lib/src/selectors/index.ts
+++ b/lib/src/selectors/index.ts
@@ -1,2 +1,3 @@
 export * from './entity-selectors';
 export * from './entity-selectors$';
+export * from './entity-cache-selector';

--- a/lib/src/selectors/related-entity-selectors.spec.ts
+++ b/lib/src/selectors/related-entity-selectors.spec.ts
@@ -72,14 +72,12 @@ describe('Related-entity Selectors', () => {
 
   describe('hero -> sidekick (1-1)', () => {
     function setCollectionSelectors() {
-      const heroSelectors = entitySelectorsFactory.create<Hero>({
-        entityName: 'Hero'
-      });
+      const heroSelectors = entitySelectorsFactory.create<Hero>('Hero');
       const selectHeroMap = heroSelectors.selectEntityMap;
 
-      const sidekickSelectors = entitySelectorsFactory.create<Sidekick>({
-        entityName: 'Sidekick'
-      });
+      const sidekickSelectors = entitySelectorsFactory.create<Sidekick>(
+        'Sidekick'
+      );
       const selectSidekickMap = sidekickSelectors.selectEntityMap;
 
       return {
@@ -224,14 +222,10 @@ describe('Related-entity Selectors', () => {
 
   describe('hero -> battles (1-m)', () => {
     function setCollectionSelectors() {
-      const heroSelectors = entitySelectorsFactory.create<Hero>({
-        entityName: 'Hero'
-      });
+      const heroSelectors = entitySelectorsFactory.create<Hero>('Hero');
       const selectHeroMap = heroSelectors.selectEntityMap;
 
-      const battleSelectors = entitySelectorsFactory.create<Battle>({
-        entityName: 'Battle'
-      });
+      const battleSelectors = entitySelectorsFactory.create<Battle>('Battle');
       const selectBattleEntities = battleSelectors.selectEntities;
 
       const selectHeroBattleMap = createSelector(
@@ -317,20 +311,14 @@ describe('Related-entity Selectors', () => {
 
   describe('hero -> heropower <- power (m-m)', () => {
     function setCollectionSelectors() {
-      const heroSelectors = entitySelectorsFactory.create<Hero>({
-        entityName: 'Hero'
-      });
+      const heroSelectors = entitySelectorsFactory.create<Hero>('Hero');
       const selectHeroMap = heroSelectors.selectEntityMap;
 
-      const powerSelectors = entitySelectorsFactory.create<Power>({
-        entityName: 'Power'
-      });
+      const powerSelectors = entitySelectorsFactory.create<Power>('Power');
       const selectPowerMap = powerSelectors.selectEntityMap;
 
       const heroPowerMapSelectors = entitySelectorsFactory.create<HeroPowerMap>(
-        {
-          entityName: 'HeroPowerMap'
-        }
+        'HeroPowerMap'
       );
       const selectHeroPowerMapEntities = heroPowerMapSelectors.selectEntities;
 


### PR DESCRIPTION
Beta 11 - makes creating related-entity selectors a little easier.
Expands API. Does have tiny breaking change. See ChangeLog