### PR TITLE
Adding an example to the docs for how to implement a custom entity data service

### DIFF
--- a/docs/entity-dataservice.md
+++ b/docs/entity-dataservice.md
@@ -2,35 +2,35 @@
 
 The _ngrx-data_ library expects to persist entity data with calls to a REST-like web api with endpoints for each entity type.
 
-The [`EntityDataService`](../lib/src/dataservices/entity-data.service.ts) maintains a registry of service classes dedicated to persisting data for a specific entity type. 
+The [`EntityDataService`](../lib/src/dataservices/entity-data.service.ts) maintains a registry of service classes dedicated to persisting data for a specific entity type.
 
 When the _ngrx-data_ library sees an action for an entity _persistence operation_, it asks the `EntityDataService` for the registered data service that makes HTTP calls for that entity type, and calls the appropriate service method.
 
-A data service is an instance of a class that implements the 
+A data service is an instance of a class that implements the
 [`EntityCollectionDataService<T>` interface](../lib/src/dataservices/entity-data.service.ts).
-This interface supports a basic set of CRUD operations that return `Observables`: 
+This interface supports a basic set of CRUD operations that return `Observables`:
 
-| Method        | Meaning |
-| ------------- |-------------|
-| `add(entity: T)` | Add a new entity|
-| `delete(id: any)` | Delete an entity by primary key value |
-| `getAll()` | Get all instances of this entity type |
-| `getById(id: any)` | Get an entity by its primary key|
-| `getWithQuery(queryParams: QueryParams` &#x7c; `string)` | Get entities that satisfy the query |
-| `update(update: Update<T>)` | Update an existing entity |
+| Method                                                   | Meaning                               |
+| -------------------------------------------------------- | ------------------------------------- |
+| `add(entity: T)`                                         | Add a new entity                      |
+| `delete(id: any)`                                        | Delete an entity by primary key value |
+| `getAll()`                                               | Get all instances of this entity type |
+| `getById(id: any)`                                       | Get an entity by its primary key      |
+| `getWithQuery(queryParams: QueryParams` &#x7c; `string)` | Get entities that satisfy the query   |
+| `update(update: Update<T>)`                              | Update an existing entity             |
 
->`QueryParams` is a _parameter-name/value_ map
->You can also supply the query string itself.
->`HttpClient` safely encodes both into an encoded query string.
+> `QueryParams` is a _parameter-name/value_ map
+> You can also supply the query string itself.
+> `HttpClient` safely encodes both into an encoded query string.
 >
->`Update<T>` is an object with a strict subset of the entity properties.
-It *must* include the properties that participate in the primary key (e.g., `id`).
-The update property values are the _properties-to-update_; 
-unmentioned properties should retain their current values.
+> `Update<T>` is an object with a strict subset of the entity properties.
+> It _must_ include the properties that participate in the primary key (e.g., `id`).
+> The update property values are the _properties-to-update_;
+> unmentioned properties should retain their current values.
 
 The default data service methods return the `Observables` returned by the corresponding Angular `HttpClient` methods.
 
->If you create your own data service alternatives, they should return similar `Observables`.
+> If you create your own data service alternatives, they should return similar `Observables`.
 
 ## Register data services
 
@@ -38,11 +38,11 @@ The `EntityDataService` registry is empty by default.
 
 You can add custom data services to it by creating instances of those classes and registering them with `EntityDataService` in one of two ways.
 
-1. register a single data service by entity name with the `registerService()` method.
+1.  register a single data service by entity name with the `registerService()` method.
 
-1. register several data services at the same time with by calling `registerServices` with an _entity-name/service_ map.
+1.  register several data services at the same time with by calling `registerServices` with an _entity-name/service_ map.
 
->You can create and import a module that registers your custom data services as show in the [EntityDataService tests](../lib/src/dataservices/entity-data.service.spec.ts)
+> You can create and import a module that registers your custom data services as show in the [EntityDataService tests](../lib/src/dataservices/entity-data.service.spec.ts)
 
 If you decide to register an entity data service, be sure to do so _before_ you ask _ngrx-data_ to perform a persistence operation for that entity.
 
@@ -54,11 +54,12 @@ The demo app doesn't register any entity data services. It relies entirely on a 
 
 A `DefaultDataService<T>` makes REST-like calls to the server's web api with Angular's `HttpClient`.
 
-It composes HTTP URLs from a _root_ path (see ["Configuration"](#configuration) below) and the entity name. 
+It composes HTTP URLs from a _root_ path (see ["Configuration"](#configuration) below) and the entity name.
 
-For example, 
+For example,
+
 * if the persistence action is to delete a hero with id=42 _and_
-* the root path is `'api'` _and_ 
+* the root path is `'api'` _and_
 * the entity name is `'Hero'`, _then_
 * the DELETE request URL will be `'api/hero/42'`.
 
@@ -68,15 +69,16 @@ The `QUERY_ALL` action to get all heroes would result in an HTTP GET request to 
 
 The `DefaultDataService` doesn't know how to pluralize the entity type name.
 It doesn't even know how to create the base resource names.
-It relies on an injected 
+It relies on an injected
 [`HttpUrlGenerator` service](../lib/src/dataservices/http-url-generator.ts) those.
-And the default implementation of that generator relies on the 
+And the default implementation of that generator relies on the
 [`Pluralizer`](../lib/src/utils/pluralizer.ts) service to
 get the collection resource name.
 The [_Entity Metadata_](entity-metadata.md#plurals) guide
 explains how to configure the default `Pluralizer` .
 
 <a name="configuration"></a>
+
 ### Configure the _DefaultDataService_
 
 The collection-level data services construct their own URLs for HTTP calls. They typically rely on shared configuration information such as the root of every resource URL.
@@ -98,3 +100,106 @@ you can save yourself the headache of ignoring a DELETE 404 error
 by setting this flag to `true`, which is the default for the `DefaultDataService<T>`.
 
 When running a demo app locally, the server may respond more quickly than it will in production. You can simulate real-world by setting the `getDelay` and `saveDelay` properties.
+
+## Further customization
+
+While the _ngrx-data_ library provides a configuration object to modify certain aspects of the _DefaultDataService_, you may want to further customize what happens when you save or retrieve data. A good example is performing a `map` on the items returned to convert strings to dates, or to add additional properties to a specific entity. This is possible by registering a custom service with the `EntityDataService` provider.
+
+To illustrate this we'll use an example where we add a date property to an entity when it was loaded from the API into the application state. If we use the Tour of Heroes as our example, let's add a assume there's a new property on `Hero` called `dateLoaded`:
+
+```typescript
+export class Hero {
+  id: number;
+  name: string;
+  saying: string;
+  dateLoaded: Date;
+}
+```
+
+Then we need to create a class that implements the `EntityCollectionDataService<T>` interface. One way to do this is to extend the existing `DefaultDataSerivce<T>` class like so (for the `Hero` class in our case):
+
+```typescript
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import {
+  EntityCollectionDataService,
+  DefaultDataService,
+  HttpUrlGenerator,
+  QueryParams
+} from 'ngrx-data';
+import { Observable } from 'rxjs/Observable';
+import { map } from 'rxjs/operators';
+import { Hero } from '../core';
+
+@Injectable()
+export class HeroEntityDataService extends DefaultDataService<Hero> {
+  constructor(http: HttpClient, httpUrlGenerator: HttpUrlGenerator) {
+    super('Hero', http, httpUrlGenerator);
+  }
+
+  getAll(): Observable<Hero[]> {
+    return super.getAll().pipe(
+      map(heroes => {
+        return heroes.map(hero => this.mapHero(hero));
+      })
+    );
+  }
+
+  getById(id: string | number): Observable<Hero> {
+    return super.getById(id).pipe(map(hero => this.mapHero(hero)));
+  }
+
+  getWithQuery(params: string | QueryParams): Observable<Hero[]> {
+    return super.getWithQuery(params).pipe(
+      map(heroes => {
+        return heroes.map(hero => this.mapHero(hero));
+      })
+    );
+  }
+
+  private mapHero(hero: Hero): Hero {
+    hero.dateLoaded = new Date();
+    return hero;
+  }
+}
+```
+
+Using this technique let's us leverage all the base functionality of `DefaultDataService<T>`, and only override what we really need. In this example we just want to hook into the various _get_ operations to perform our `map` on the entities. You could choose not to extend anything and write your own complete implementation too. It all depends on the needs of your application.
+
+Finally, we need to tell _ngrx-data_ about this new provider, and we can use the `registerService()` method on the `EntityDataService` provider in our store module:
+
+```typescript
+import { NgModule } from '@angular/core';
+import {
+  EntityMetadataMap,
+  NgrxDataModule,
+  EntityDataService
+} from 'ngrx-data';
+import { HeroEntityDataService } from './hero-entity-data-service.service';
+
+export const entityMetadata: EntityMetadataMap = {
+  Hero: {},
+  Villain: {}
+};
+
+// because the plural of "hero" is not "heros"
+export const pluralNames = { Hero: 'Heroes' };
+
+@NgModule({
+  imports: [
+    NgrxDataModule.forRoot({
+      entityMetadata: entityMetadata,
+      pluralNames: pluralNames
+    })
+  ],
+  providers: [HeroEntityDataService]
+})
+export class EntityStoreModule {
+  constructor(
+    heroEntityDataService: HeroEntityDataService,
+    entityDataService: EntityDataService
+  ) {
+    entityDataService.registerService('Hero', heroEntityDataService);
+  }
+}
+```


### PR DESCRIPTION
Adding an example for how to implement a custom entity data service

## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This PR adds a simple example for how to create and register custom entity data services, which will be common in scenarios where people was to override the default behavior when retrieving and saving data.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
This is a result of the discussion in https://github.com/johnpapa/angular-ngrx-data/issues/143. It also seems that Prettier made some small updates to whitespace in certain parts of the document. I didn't change anything except to add the _Further customization_ section at the end.