### PR TITLE
feat: 6.1.0-alpha.2 enhancements

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
-  "printWidth": 140,
+  "printWidth": 100,
   "singleQuote": true,
   "tabWidth": 2
 }

--- a/docs/save-entities.md
+++ b/docs/save-entities.md
@@ -30,23 +30,45 @@ methods make it easier to create and dispatch all of the entity cache actions.
 Save a bunch of entity changes with the `saveEntities()` dispatcher method.
 Call it with a URL and a `ChangeSet` describing the entity changes that the server API (at the URL endpoint) should save.
 
-Here's an example.
+The sample application demonstrates a simple `saveEntities` scenario.
+A button on the _Villains_ page deletes all of the villains.
+
+In the following example, we want to add a `Hero` and delete two `Villains` in the same transaction.
+We assume a server is ready to handle such a request.
+
+First create the `ChangeSetItems` for the `ChangeSet`.
 
 ```
-// Add a Hero; delete two Villains by their ids
-const changes: ChangeSetItem[] =  [
+import { ChangeSetOperation } from 'ngrx-data';
+...
+const changes =  [
   {
     op: ChangeSetOperation.Add,
     entityName: 'Hero',
-    entities: [{ id: 1, name: 'A1 Add' }]
+    entities: [hero]
   },
   {
     op: ChangeSetOperation.Delete,
     entityName: 'Villain',
-    entities: [2, 3]
+    entities: [2, 3] // delete by their ids
   }
 ];
+```
 
+The `changeSetItemFactory` makes it easier to write these changes.
+
+```
+import { changeSetItemFactory as cif } from 'ngrx-data';
+...
+const changes = [
+  cif.add('Hero', hero),
+  cif.delete('Villain', [2, 3])
+];
+```
+
+Now dispatch a `saveEntities` with a `ChangeSet` for those changes.
+
+```
 const changeSet: ChangeSet = { changes, tag: 'Hello World'}
 
 cacheEntityDispatcher.saveEntities(changeSet, saveUrl).subscribe(
@@ -54,8 +76,9 @@ cacheEntityDispatcher.saveEntities(changeSet, saveUrl).subscribe(
 );
 ```
 
-The `saveEntities(changeSet, url)` returns an `Observable<ChangeSet>`,
-which emits a new `ChangeSet` after the server returns a successful response.
+The `saveEntities(changeSet, saveUrl)` returns an `Observable<ChangeSet>`,
+which emits a new `ChangeSet` after the server API (at the `saveUrl` endpoint) returns a successful response.
+
 That emitted `ChangeSet` holds the server's response data for all affected entities.
 
 The app can wait for the `saveEntities()` observable to terminate (either successfully or with an error), before proceeding (e.g., routing to another page).

--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -22,10 +22,26 @@ In other words, it is safer to have something like the following in your `packag
 as this will keep you from installing `6.1.x`.
 
 <hr>
+<a id="6.1.0-alpha.2"></a>
+
+# 6.1.0-alpha.2 (2018-09-19)
+
+Non-breaking enhancements
+
+* add `ChangeSetItemFactory` and `changeSetItemFactory` instance to make creating a `ChangeSet` easier.
+* add `excludeEmptyChangeSetItems` function that filters out empty changes in `ChangeSet`s.
+* `EntityCacheDataService.saveEntities` calls `excludeEmptyChangeSetItems` before sending to the server.
+* if no changes to save, `EntityCacheEffect.saveEntities` returns success immediately, w/o calling data service.
+* changed _prettier_ line length from 140 to 100 which will cause innocuous file changes over time.
+
+_TODO: more unit tests_
+
+* `EntityCacheDataService`
+* `EntityCacheDispatcher`
 
 <a id="6.1.0-alpha.1"></a>
 
-# 6.1.0-alpha.1 (2018-09-09)
+# 6.1.0-alpha.1 (2018-09-18)
 
 A "major" release with significant new features.
 

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngrx-data",
-  "version": "6.1.0-alpha.1",
+  "version": "6.1.0-alpha.2",
   "repository": "https://github.com/johnpapa/angular-ngrx-data.git",
   "license": "MIT",
   "peerDependencies": {

--- a/lib/src/actions/entity-cache-change-set.ts
+++ b/lib/src/actions/entity-cache-change-set.ts
@@ -55,3 +55,50 @@ export interface ChangeSet<T = any> {
   /** An arbitrary string, identifying the ChangeSet and perhaps its purpose */
   tag?: string;
 }
+
+/**
+ * Factory to create a ChangeSetItem for a ChangeSetOperation
+ */
+export class ChangeSetItemFactory {
+  /** Create the ChangeSetAdd for new entities of the given entity type */
+  add<T>(entityName: string, entities: T | T[]): ChangeSetAdd<T> {
+    entities = Array.isArray(entities) ? entities : entities ? [entities] : [];
+    return { entityName, op: ChangeSetOperation.Add, entities };
+  }
+
+  /** Create the ChangeSetDelete for primary keys of the given entity type */
+  delete(entityName: string, keys: number | number[] | string | string[]): ChangeSetDelete {
+    const ids = Array.isArray(keys) ? keys : keys ? ([keys] as string[] | number[]) : [];
+    return { entityName, op: ChangeSetOperation.Delete, entities: ids };
+  }
+
+  /** Create the ChangeSetUpdate for Updates of entities of the given entity type */
+  update<T extends { id: string }>(
+    entityName: string,
+    updates: Update<T> | Update<T>[]
+  ): ChangeSetUpdate<T> {
+    updates = Array.isArray(updates) ? updates : updates ? [updates] : [];
+    return { entityName, op: ChangeSetOperation.Update, entities: updates };
+  }
+
+  /** Create the ChangeSetUpsert for new or existing entities of the given entity type */
+  upsert<T>(entityName: string, entities: T | T[]): ChangeSetUpsert<T> {
+    entities = Array.isArray(entities) ? entities : entities ? [entities] : [];
+    return { entityName, op: ChangeSetOperation.Upsert, entities };
+  }
+}
+
+/**
+ * Instance of a factory to create a ChangeSetItem for a ChangeSetOperation
+ */
+export const changeSetItemFactory = new ChangeSetItemFactory();
+
+/**
+ * Return ChangeSet after filtering out null and empty ChangeSetItems.
+ * @param changeSet ChangeSet with changes to filter
+ */
+export function excludeEmptyChangeSetItems(changeSet: ChangeSet): ChangeSet {
+  changeSet = changeSet && changeSet.changes ? changeSet : { changes: [] };
+  const changes = changeSet.changes.filter(c => c != null && c.entities && c.entities.length > 0);
+  return { ...changeSet, changes };
+}

--- a/lib/src/actions/entity-cache-changes-set.spec.ts
+++ b/lib/src/actions/entity-cache-changes-set.spec.ts
@@ -1,0 +1,32 @@
+import {
+  ChangeSet,
+  ChangeSetOperation,
+  changeSetItemFactory as cif
+} from './entity-cache-change-set';
+
+describe('changeSetItemFactory', () => {
+  const hero = { id: 1, name: 'Hero 1' };
+  const villains = [{ id: 2, name: 'Villain 2' }, { id: 3, name: 'Villain 3' }];
+
+  it('should create an Add item with array of entities from single entity', () => {
+    const heroItem = cif.add('Hero', hero);
+    expect(heroItem.op).toBe(ChangeSetOperation.Add);
+    expect(heroItem.entityName).toBe('Hero');
+    expect(heroItem.entities).toEqual([hero]);
+  });
+
+  it('should create a Delete item from an array entity keys', () => {
+    const ids = villains.map(v => v.id);
+    const heroItem = cif.delete('Villain', ids);
+    expect(heroItem.op).toBe(ChangeSetOperation.Delete);
+    expect(heroItem.entityName).toBe('Villain');
+    expect(heroItem.entities).toEqual(ids);
+  });
+
+  it('should create an Add item with empty array when given no entities', () => {
+    const heroItem = cif.add('Hero', null);
+    expect(heroItem.op).toBe(ChangeSetOperation.Add);
+    expect(heroItem.entityName).toBe('Hero');
+    expect(heroItem.entities).toEqual([]);
+  });
+});

--- a/src/app/villains/villains.service.ts
+++ b/src/app/villains/villains.service.ts
@@ -6,7 +6,7 @@ import { filter, first, map, shareReplay, tap } from 'rxjs/operators';
 
 import {
   ChangeSet,
-  ChangeSetOperation,
+  changeSetItemFactory as cif,
   EntityCacheDispatcher,
   EntityCollectionServiceBase,
   EntityCollectionServiceElementsFactory
@@ -20,7 +20,10 @@ export class VillainsService extends EntityCollectionServiceBase<Villain> {
   filterObserver: FilterObserver;
 
   /** Run `getAll` if the datasource changes. */
-  getAllOnDataSourceChange = this.appSelectors.dataSource$.pipe(tap(_ => this.getAll()), shareReplay(1));
+  getAllOnDataSourceChange = this.appSelectors.dataSource$.pipe(
+    tap(_ => this.getAll()),
+    shareReplay(1)
+  );
   constructor(
     private appSelectors: AppSelectors,
     private entityCacheDispatcher: EntityCacheDispatcher,
@@ -54,13 +57,7 @@ export class VillainsService extends EntityCollectionServiceBase<Villain> {
     const deleteAllChangeSet$ = (this.keys$ as Observable<number[]>).pipe(
       map(keys => {
         const changeSet: ChangeSet = {
-          changes: [
-            {
-              entityName: 'Villain',
-              op: ChangeSetOperation.Delete,
-              entities: keys
-            }
-          ],
+          changes: [cif.delete('Villain', keys)],
           tag: 'DELETE ALL VILLAINS' // optional descriptive tag
         };
         return changeSet;


### PR DESCRIPTION
Add enhancements to `saveEntities` feature introduced in v6.1.0-alpha.1, derived from usage patterns emerging in a real app.

No breaking changes.